### PR TITLE
quic: fix type in node_quic_buffer

### DIFF
--- a/src/node_quic_buffer.h
+++ b/src/node_quic_buffer.h
@@ -284,7 +284,7 @@ class QuicBuffer : public MemoryRetainer {
   // read head_ can be advanced.
   inline size_t DrainInto(
       std::vector<uv_buf_t>* list,
-      uint64_t* length = nullptr) {
+      size_t* length = nullptr) {
     size_t len = 0;
     bool seen_head = false;
     quic_buffer_chunk* pos = head_;
@@ -305,7 +305,7 @@ class QuicBuffer : public MemoryRetainer {
 
   inline size_t DrainInto(
       std::vector<ngtcp2_vec>* list,
-      uint64_t* length = nullptr) {
+      size_t* length = nullptr) {
     size_t len = 0;
     bool seen_head = false;
     quic_buffer_chunk* pos = head_;


### PR DESCRIPTION
Fixup type issue
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
