### PR TITLE
quic: fixup type issue

### DIFF
--- a/src/node_quic_session-inl.h
+++ b/src/node_quic_session-inl.h
@@ -624,12 +624,6 @@ inline void QuicSession::SetLastError(QuicErrorFamily family, uint64_t code) {
   last_error_.code = code;
 }
 
-inline void QuicSession::SetLastError(QuicErrorFamily family, ssize_t code) {
-  SetLastError(
-      family,
-      ngtcp2_err_infer_quic_transport_error_code(static_cast<int>(code)));
-}
-
 inline void QuicSession::SetLastError(QuicErrorFamily family, int code) {
   SetLastError(family, ngtcp2_err_infer_quic_transport_error_code(code));
 }

--- a/src/node_quic_session.cc
+++ b/src/node_quic_session.cc
@@ -1063,7 +1063,7 @@ bool QuicSession::SendStreamData(QuicStream* stream) {
           return true;
         default:
           Debug(stream, "Error writing packet. Code %" PRIu64, nwrite);
-          SetLastError(QUIC_ERROR_SESSION, nwrite);
+          SetLastError(QUIC_ERROR_SESSION, static_cast<int>(nwrite));
           return false;
       }
     }
@@ -1413,7 +1413,7 @@ bool QuicSession::WritePackets() {
     if (nwrite == 0)
       return true;
     else if (nwrite <= 0) {
-      SetLastError(QUIC_ERROR_SESSION, nwrite);
+      SetLastError(QUIC_ERROR_SESSION, static_cast<int>(nwrite));
       return false;
     }
     data.Realloc(nwrite);
@@ -2080,7 +2080,7 @@ bool QuicServerSession::StartClosingPeriod() {
           error.code,
           uv_hrtime());
   if (nwrite < 0) {
-    SetLastError(QUIC_ERROR_SESSION, nwrite);
+    SetLastError(QUIC_ERROR_SESSION, static_cast<int>(nwrite));
     return false;
   }
   conn_closebuf_.Realloc(nwrite);
@@ -2567,7 +2567,7 @@ bool QuicClientSession::SendConnectionClose() {
         uv_hrtime());
   if (nwrite < 0) {
     Debug(this, "Error writing connection close: %d", nwrite);
-    SetLastError(QUIC_ERROR_SESSION, nwrite);
+    SetLastError(QUIC_ERROR_SESSION, static_cast<int>(nwrite));
     return false;
   }
   data.Realloc(nwrite);

--- a/src/node_quic_session.h
+++ b/src/node_quic_session.h
@@ -273,7 +273,6 @@ class QuicSession : public AsyncWrap,
           NGTCP2_NO_ERROR
       });
   inline void SetLastError(QuicErrorFamily family, uint64_t error_code);
-  inline void SetLastError(QuicErrorFamily family, ssize_t error_code);
   inline void SetLastError(QuicErrorFamily family, int error_code);
   int SetRemoteTransportParams(ngtcp2_transport_params* params);
 


### PR DESCRIPTION
Eventually, James, you're going to remember that size_t and ssize_t
are typedef'd differently on mac and some other oses... sigh.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
