### PR TITLE
quic: add beginnings of a ping API

### DIFF
--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -315,6 +315,19 @@ Returns a new `QuicStream`.
 An error will be thrown if the `QuicSession` has been destroyed or is in the
 process of a graceful shutdown.
 
+### quicsession.ping()
+<!--YAML
+added: REPLACEME
+-->
+
+The `ping()` method will trigger the underlying QUIC connection to serialize
+any frames currently pending in the outbound queue if it is able to do so.
+This has the effect of keeping the connection with the peer active and resets
+the idle and retransmission timers. The `ping()` method is a best-effort
+that ignores any errors that may occur during the serialization and send
+operations. There is no return value and there is no way to monitor the status
+of the `ping()` operation.
+
 ### quicsession.servername
 <!-- YAML
 added: REPLACEME

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -1458,6 +1458,12 @@ class QuicSession extends EventEmitter {
         this[kHandle].getPeerCertificate(detailed) || {}) : {};
   }
 
+  ping() {
+    if (!this[kHandle])
+      throw new ERR_QUICSESSION_DESTROYED('ping');
+    this[kHandle].ping();
+  }
+
   get servername() {
     return this.#servername;
   }

--- a/src/node_quic_session.h
+++ b/src/node_quic_session.h
@@ -252,6 +252,7 @@ class QuicSession : public AsyncWrap,
   void OnIdleTimeout();
   bool OpenBidirectionalStream(int64_t* stream_id);
   bool OpenUnidirectionalStream(int64_t* stream_id);
+  void Ping();
   size_t ReadPeerHandshake(uint8_t* buf, size_t buflen);
   bool Receive(
       ssize_t nread,


### PR DESCRIPTION
Beginnings of a simple PING api.. see: https://github.com/nodejs/quic/issues/37

This adds a single `ping()` method to `QuicSession` that will effectively just trigger serialization and sending of any frames currently pending in the ngtcp2_conn queue (this will include probe packets to test for connection liveness).

Unlike `ping()` in http/2, there is no response to ping in QUIC that we can monitor.

The QUIC `ping()` method is used only to keep the connection alive while we're not transmitting any stream packets, etc. The idle and retransmit timeouts will be updated and (currently) any errors that may occur trying to send the frames will be ignored, but that may change in the future.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
