### PR TITLE
quic: add option to use an LRU for validateAddress

### DIFF
--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -83,6 +83,11 @@ added: REPLACEME
   * `validateAddress` {boolean} When `true`, the `QuicSocket` will use explicit
     address validation using a QUIC `RETRY` frame when listening for new server
     sessions. Default: `false`.
+  * `validateAddressLRU` {boolean} When `true`, validation will be skipped if
+    the address has been recently validated. Currently, only the 10 most
+    recently validated addresses are remembered. Setting `validateAddressLRU`
+    to `true`, will enable the `validateAddress` option as well. Default:
+    `false`.
 
 Creates a new `QuicSocket` instance.
 

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -122,6 +122,7 @@ const {
     QUICCLIENTSESSION_OPTION_REQUEST_OCSP,
     QUICCLIENTSESSION_OPTION_VERIFY_HOSTNAME_IDENTITY,
     QUICSOCKET_OPTIONS_VALIDATE_ADDRESS,
+    QUICSOCKET_OPTIONS_VALIDATE_ADDRESS_LRU,
   }
 } = internalBinding('quic');
 
@@ -633,10 +634,12 @@ class QuicSocket extends EventEmitter {
       server,                // Default configuration for QuicServerSessions
       type,                  // 'udp4' or 'udp6'
       validateAddress,       // True if address verification should be used.
+      validateAddressLRU,    // True if an LRU should be used for add validation
     } = validateQuicSocketOptions(options || {});
     super();
     const socketOptions =
-      validateAddress ? QUICSOCKET_OPTIONS_VALIDATE_ADDRESS : 0;
+      (validateAddress ? QUICSOCKET_OPTIONS_VALIDATE_ADDRESS : 0) |
+      (validateAddressLRU ? QUICSOCKET_OPTIONS_VALIDATE_ADDRESS_LRU : 0);
     const handle =
       new QuicSocketHandle(
         socketOptions,

--- a/lib/internal/quic/util.js
+++ b/lib/internal/quic/util.js
@@ -328,6 +328,7 @@ function validateQuicSocketOptions(options) {
     server,
     type = 'udp4',
     validateAddress = false,
+    validateAddressLRU = false,
     retryTokenTimeout = DEFAULT_RETRYTOKEN_EXPIRATION,
   } = { ...options };
   validateBindOptions(port, address);
@@ -344,6 +345,12 @@ function validateQuicSocketOptions(options) {
       'options.validateAddress',
       'boolean',
       validateAddress);
+  }
+  if (typeof validateAddressLRU !== 'boolean') {
+    throw new ERR_INVALID_ARG_TYPE(
+      'options.validateAddressLRU',
+      'boolean',
+      validateAddressLRU);
   }
   validateNumberInBoundedRange(
     retryTokenTimeout,
@@ -365,7 +372,8 @@ function validateQuicSocketOptions(options) {
     reuseAddr,
     server,
     type: getSocketType(type),
-    validateAddress
+    validateAddress: validateAddress || validateAddressLRU,
+    validateAddressLRU,
   };
 }
 

--- a/src/node_quic.cc
+++ b/src/node_quic.cc
@@ -272,6 +272,9 @@ void Initialize(Local<Object> target,
   NODE_DEFINE_CONSTANT(
       constants,
       QUICSOCKET_OPTIONS_VALIDATE_ADDRESS);
+  NODE_DEFINE_CONSTANT(
+      constants,
+      QUICSOCKET_OPTIONS_VALIDATE_ADDRESS_LRU);
 
   target->Set(context,
               env->constants_string(),

--- a/src/node_quic_socket.h
+++ b/src/node_quic_socket.h
@@ -14,6 +14,7 @@
 #include "v8.h"
 #include "uv.h"
 
+#include <deque>
 #include <map>
 #include <string>
 #include <vector>
@@ -28,8 +29,18 @@ using v8::Value;
 
 namespace quic {
 
+static constexpr size_t MAX_VALIDATE_ADDRESS_LRU = 10;
+
 typedef enum QuicSocketOptions : uint32_t {
-  QUICSOCKET_OPTIONS_VALIDATE_ADDRESS = 0x1
+  // When enabled the QuicSocket will validate the address
+  // using a RETRY packet to the peer.
+  QUICSOCKET_OPTIONS_VALIDATE_ADDRESS = 0x1,
+
+  // When enabled, and the VALIDATE_ADDRESS option is also
+  // set, the QuicSocket will use an LRU cache to track
+  // validated addresses. Address validation will be skipped
+  // if the address is currently in the cache.
+  QUICSOCKET_OPTIONS_VALIDATE_ADDRESS_LRU = 0x2,
 } QuicSocketOptions;
 
 class QuicSocket : public HandleWrap,
@@ -149,6 +160,10 @@ class QuicSocket : public HandleWrap,
       QuicCID* scid,
       const sockaddr* addr);
 
+  void SetValidatedAddress(const sockaddr* addr);
+
+  bool IsValidatedAddress(const sockaddr* addr);
+
   std::shared_ptr<QuicSession> AcceptInitialPacket(
       uint32_t version,
       QuicCID* dcid,
@@ -246,6 +261,12 @@ class QuicSocket : public HandleWrap,
   // until the value falls back below the limit.
   std::unordered_map<const sockaddr*, size_t, SocketAddress::Hash>
     addr_counts_;
+
+  // The validated_addrs vector is used as an LRU cache for
+  // validated addresses only when the VALIDATE_ADDRESS_LRU
+  // option is set.
+  typedef size_t SocketAddressHash;
+  std::deque<SocketAddressHash> validated_addrs_;
 
   struct socket_stats {
     // The timestamp at which the socket was created

--- a/src/node_quic_socket.h
+++ b/src/node_quic_socket.h
@@ -262,7 +262,7 @@ class QuicSocket : public HandleWrap,
   std::unordered_map<const sockaddr*, size_t, SocketAddress::Hash>
     addr_counts_;
 
-  // The validated_addrs vector is used as an LRU cache for
+  // The validated_addrs_ vector is used as an LRU cache for
   // validated addresses only when the VALIDATE_ADDRESS_LRU
   // option is set.
   typedef size_t SocketAddressHash;

--- a/src/node_quic_util.h
+++ b/src/node_quic_util.h
@@ -309,7 +309,6 @@ class SocketAddress {
 class SocketAddressLRU : public MemoryRetainer {
  public:
  private:
-
 };
 
 class QuicPath {

--- a/src/node_quic_util.h
+++ b/src/node_quic_util.h
@@ -306,6 +306,12 @@ class SocketAddress {
   sockaddr_storage address_;
 };
 
+class SocketAddressLRU : public MemoryRetainer {
+ public:
+ private:
+
+};
+
 class QuicPath {
  public:
   QuicPath(


### PR DESCRIPTION
Optionally allow address validation to be skipped for
recently validated addresses.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
