### PR TITLE
quic: expose tracking histograms to js

### DIFF
--- a/lib/internal/histogram.js
+++ b/lib/internal/histogram.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const {
+  customInspectSymbol: kInspect,
+} = require('internal/util');
+
+const { format } = require('util');
+
+const kHandle = Symbol('kHandle');
+const kDestroy = Symbol('kDestroy');
+
+class Histogram {
+  constructor(internal) {
+    this[kHandle] = internal;
+  }
+
+  [kInspect]() {
+    const obj = {
+      min: this.min,
+      max: this.max,
+      mean: this.mean,
+      exceeds: this.exceeds,
+      stddev: this.stddev,
+      percentiles: this.percentiles,
+    };
+    return `Histogram ${format(obj)}`;
+  }
+
+  get min() {
+    return this[kHandle] ? this[kHandle].min() : undefined;
+  }
+
+  get max() {
+    return this[kHandle] ? this[kHandle].max() : undefined;
+  }
+
+  get mean() {
+    return this[kHandle] ? this[kHandle].mean() : undefined;
+  }
+
+  get exceeds() {
+    return this[kHandle] ? this[kHandle].exceeds() : undefined;
+  }
+
+  get stddev() {
+    return this[kHandle] ? this[kHandle].stddev() : undefined;
+  }
+
+  percentile(percentile) {
+    return this[kHandle] ? this[kHandle].percentile(percentile) : undefined;
+  }
+
+  get percentiles() {
+    const map = new Map();
+    if (this[kHandle])
+      this[kHandle].percentiles(map);
+    return map;
+  }
+
+  reset() {
+    if (this[kHandle])
+      this[kHandle].reset();
+  }
+
+  [kDestroy]() {
+    this[kHandle] = undefined;
+  }
+}
+
+module.exports = { Histogram, kDestroy: kDestroy };

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -123,6 +123,11 @@ const {
   }
 } = internalBinding('quic');
 
+const {
+  Histogram,
+  kDestroy: kDestroyHistogram
+} = require('internal/histogram');
+
 const DEFAULT_QUIC_CIPHERS = 'TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:' +
                              'TLS_CHACHA20_POLY1305_SHA256';
 const DEFAULT_GROUPS = 'P-256:X25519:P-384:P-521';
@@ -150,6 +155,7 @@ const kReceiveStop = Symbol('kReceiveStop');
 const kRemoveSession = Symbol('kRemove');
 const kRemoveStream = Symbol('kRemoveStream');
 const kServerBusy = Symbol('kServerBusy');
+const kSetHandle = Symbol('kSetHandle');
 const kSetSocket = Symbol('kSetSocket');
 const kStatelessReset = Symbol('kStatelessReset');
 const kStreamClose = Symbol('kStreamClose');
@@ -673,7 +679,7 @@ class QuicSocket extends EventEmitter {
         maxConnectionsPerHost);
     handle[owner_symbol] = this;
     this[async_id_symbol] = handle.getAsyncId();
-    this[kHandle] = handle;
+    this[kSetHandle](handle);
     this.#address = address || (type === AF_INET6 ? '::' : '0.0.0.0');
     this.#autoClose = autoClose;
     this.#client = client;
@@ -683,6 +689,10 @@ class QuicSocket extends EventEmitter {
     this.#reuseAddr = reuseAddr;
     this.#server = server;
     this.#type = type;
+  }
+
+  [kSetHandle](handle) {
+    this[kHandle] = handle;
   }
 
   [kInspect]() {
@@ -906,7 +916,7 @@ class QuicSocket extends EventEmitter {
   [kDestroy](error) {
     const handle = this[kHandle];
     if (handle !== undefined) {
-      this[kHandle] = undefined;
+      this[kSetHandle]();
       handle[owner_symbol] = undefined;
       handle.close((err) => {
         // If an error occurs while attempting to close, it will take
@@ -1305,6 +1315,8 @@ class QuicSession extends EventEmitter {
   #streams = new Map();
   #verifyErrorReason = undefined;
   #verifyErrorCode = undefined;
+  #handshakeAckHistogram = undefined;
+  #handshakeContinuationHistogram = undefined;
 
   constructor(socket, servername) {
     super();
@@ -1313,6 +1325,21 @@ class QuicSession extends EventEmitter {
     this.#socket = socket;
     socket[kAddSession](this);
     this.#servername = servername;
+  }
+
+  [kSetHandle](handle) {
+    this[kHandle] = handle;
+    if (handle !== undefined) {
+      this.#handshakeAckHistogram =
+        new Histogram(handle.crypto_rx_ack);
+      this.#handshakeContinuationHistogram =
+        new Histogram(handle.crypto_handshake_rate);
+    } else {
+      if (this.#handshakeAckHistogram)
+        this.#handshakeAckHistogram[kDestroyHistogram]();
+      if (this.#handshakeContinuationHistogram)
+        this.#handshakeContinuationHistogram[kDestroyHistogram]();
+    }
   }
 
   [kVersionNegotiation](version, requestedVersions, supportedVersions) {
@@ -1374,6 +1401,10 @@ class QuicSession extends EventEmitter {
       destroyed: this.destroyed,
       servername: this.servername,
       streams: this.#streams.size,
+      stats: {
+        handshakeAck: this.handshakeAckHistogram,
+        handshakeContinuation: this.handshakeContinuationHistogram,
+      }
     };
     return `${this.constructor.name} ${util.format(obj)}`;
   }
@@ -1516,7 +1547,7 @@ class QuicSession extends EventEmitter {
     const handle = this[kHandle];
     if (handle !== undefined) {
       handle[owner_symbol] = undefined;
-      this[kHandle] = undefined;
+      this[kSetHandle]();
       // Copy the stats and recoveryStats for use after destruction
       this.#stats = new BigInt64Array(handle.stats);
       this.#recoveryStats = new Float64Array(handle.recoveryStats);
@@ -1728,13 +1759,21 @@ class QuicSession extends EventEmitter {
       throw new ERR_QUICSESSION_UPDATEKEY();
     return this[kHandle].updateKey();
   }
+
+  get handshakeAckHistogram() {
+    return this.#handshakeAckHistogram;
+  }
+
+  get handshakeContinuationHistogram() {
+    return this.#handshakeContinuationHistogram;
+  }
 }
 
 class QuicServerSession extends QuicSession {
   #contexts = [];
   constructor(socket, handle) {
     super(socket);
-    this[kHandle] = handle;
+    this[kSetHandle](handle);
     handle[owner_symbol] = this;
   }
 
@@ -1941,7 +1980,7 @@ class QuicClientSession extends QuicSession {
   }
 
   [kInit](handle) {
-    this[kHandle] = handle;
+    this[kSetHandle](handle);
     handle[owner_symbol] = this;
     this.#handleReady = true;
     this[kMaybeReady]();
@@ -1968,7 +2007,7 @@ class QuicClientSession extends QuicSession {
   get ephemeralKeyInfo() {
     return this[kHandle] !== undefined ?
       this[kHandle].getEphemeralKeyInfo() :
-      undefined;
+      {};
   }
 
   setSocket(socket, callback) {
@@ -2004,6 +2043,9 @@ class QuicStream extends Duplex {
   #resetCode = undefined;
   #resetFinalSize = undefined;
   #session = undefined;
+  #dataRateHistogram = undefined;
+  #dataSizeHistogram = undefined;
+  #dataAckHistogram = undefined;
 
   constructor(options, session, id, handle) {
     super({
@@ -2015,7 +2057,7 @@ class QuicStream extends Duplex {
     handle.onread = onStreamRead;
     handle[owner_symbol] = this;
     this[async_id_symbol] = handle.getAsyncId();
-    this[kHandle] = handle;
+    this[kSetHandle](handle);
     this.#id = id;
     this.#session = session;
     this._readableState.readingMore = true;
@@ -2040,6 +2082,22 @@ class QuicStream extends Duplex {
         this.push(null);
         this.read();
       }
+    }
+  }
+
+  [kSetHandle](handle) {
+    this[kHandle] = handle;
+    if (handle !== undefined) {
+      this.#dataRateHistogram = new Histogram(handle.data_rx_rate);
+      this.#dataSizeHistogram = new Histogram(handle.data_rx_size);
+      this.#dataAckHistogram = new Histogram(handle.data_rx_ack);
+    } else {
+      if (this.#dataRateHistogram)
+        this.#dataRateHistogram[kDestroyHistogram]();
+      if (this.#dataSizeHistogram)
+        this.#dataSizeHistogram[kDestroyHistogram]();
+      if (this.#dataAckHistogram)
+        this.#dataAckHistogram[kDestroyHistogram]();
     }
   }
 
@@ -2124,6 +2182,11 @@ class QuicStream extends Duplex {
       initiated,
       writableState: this._writableState,
       readableState: this._readableState,
+      stats: {
+        dataRate: this.dataRateHistogram,
+        dataSize: this.dataSizeHistogram,
+        dataAck: this.dataAckHistogram,
+      }
     };
     return `QuicStream ${util.format(obj)}`;
   }
@@ -2230,6 +2293,18 @@ class QuicStream extends Duplex {
 
   [kUpdateTimer]() {
     // TODO(@jasnell): Implement this later
+  }
+
+  get dataRateHistogram() {
+    return this.#dataRateHistogram;
+  }
+
+  get dataSizeHistogram() {
+    return this.#dataSizeHistogram;
+  }
+
+  get dataAckHistogram() {
+    return this.#dataAckHistogram;
   }
 }
 

--- a/node.gyp
+++ b/node.gyp
@@ -130,6 +130,7 @@
       'lib/internal/fs/sync_write_stream.js',
       'lib/internal/fs/utils.js',
       'lib/internal/fs/watchers.js',
+      'lib/internal/histogram.js',
       'lib/internal/http.js',
       'lib/internal/idna.js',
       'lib/internal/inspector_async_hook.js',

--- a/src/env.h
+++ b/src/env.h
@@ -391,6 +391,7 @@ constexpr size_t kFsStatsBufferLength =
   V(filehandlereadwrap_template, v8::ObjectTemplate)                           \
   V(fsreqpromise_constructor_template, v8::ObjectTemplate)                     \
   V(handle_wrap_ctor_template, v8::FunctionTemplate)                           \
+  V(histogram_ctor_template, v8::ObjectTemplate)                               \
   V(http2settings_constructor_template, v8::ObjectTemplate)                    \
   V(http2stream_constructor_template, v8::ObjectTemplate)                      \
   V(http2ping_constructor_template, v8::ObjectTemplate)                        \

--- a/src/histogram-inl.h
+++ b/src/histogram-inl.h
@@ -4,6 +4,7 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "histogram.h"
+#include "base_object-inl.h"
 #include "node_internals.h"
 
 namespace node {
@@ -54,6 +55,152 @@ inline void Histogram::Percentiles(std::function<void(double, double)> fn) {
     double value = static_cast<double>(iter.value);
     fn(key, value);
   }
+}
+
+inline HistogramBase::HistogramBase(
+    Environment* env,
+    v8::Local<v8::Object> wrap,
+    int64_t lowest,
+    int64_t highest,
+    int figures) :
+    BaseObject(env, wrap),
+    Histogram(lowest, highest, figures) {}
+
+inline bool HistogramBase::RecordDelta() {
+  uint64_t time = uv_hrtime();
+  bool ret = true;
+  if (prev_ > 0) {
+    int64_t delta = time - prev_;
+    if (delta > 0) {
+      ret = Record(delta);
+      TraceDelta(delta);
+      if (!ret) {
+        if (exceeds_ < 0xFFFFFFFF)
+          exceeds_++;
+        TraceExceeds(delta);
+      }
+    }
+  }
+  prev_ = time;
+  return ret;
+}
+
+inline void HistogramBase::ResetState() {
+  Reset();
+  exceeds_ = 0;
+  prev_ = 0;
+}
+
+inline void HistogramBase::HistogramMin(
+    const v8::FunctionCallbackInfo<v8::Value>& args) {
+  HistogramBase* histogram;
+  ASSIGN_OR_RETURN_UNWRAP(&histogram, args.Holder());
+  double value = static_cast<double>(histogram->Min());
+  args.GetReturnValue().Set(value);
+}
+
+inline void HistogramBase::HistogramMax(
+    const v8::FunctionCallbackInfo<v8::Value>& args) {
+  HistogramBase* histogram;
+  ASSIGN_OR_RETURN_UNWRAP(&histogram, args.Holder());
+  double value = static_cast<double>(histogram->Max());
+  args.GetReturnValue().Set(value);
+}
+
+inline void HistogramBase::HistogramMean(
+    const v8::FunctionCallbackInfo<v8::Value>& args) {
+  HistogramBase* histogram;
+  ASSIGN_OR_RETURN_UNWRAP(&histogram, args.Holder());
+  args.GetReturnValue().Set(histogram->Mean());
+}
+
+inline void HistogramBase::HistogramExceeds(
+    const v8::FunctionCallbackInfo<v8::Value>& args) {
+  HistogramBase* histogram;
+  ASSIGN_OR_RETURN_UNWRAP(&histogram, args.Holder());
+  double value = static_cast<double>(histogram->Exceeds());
+  args.GetReturnValue().Set(value);
+}
+
+inline void HistogramBase::HistogramStddev(
+    const v8::FunctionCallbackInfo<v8::Value>& args) {
+  HistogramBase* histogram;
+  ASSIGN_OR_RETURN_UNWRAP(&histogram, args.Holder());
+  args.GetReturnValue().Set(histogram->Stddev());
+}
+
+inline void HistogramBase::HistogramPercentile(
+    const v8::FunctionCallbackInfo<v8::Value>& args) {
+  HistogramBase* histogram;
+  ASSIGN_OR_RETURN_UNWRAP(&histogram, args.Holder());
+  CHECK(args[0]->IsNumber());
+  double percentile = args[0].As<v8::Number>()->Value();
+  args.GetReturnValue().Set(histogram->Percentile(percentile));
+}
+
+inline void HistogramBase::HistogramPercentiles(
+    const v8::FunctionCallbackInfo<v8::Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  HistogramBase* histogram;
+  ASSIGN_OR_RETURN_UNWRAP(&histogram, args.Holder());
+  CHECK(args[0]->IsMap());
+  v8::Local<v8::Map> map = args[0].As<v8::Map>();
+  histogram->Percentiles([&](double key, double value) {
+    map->Set(
+        env->context(),
+        v8::Number::New(env->isolate(), key),
+        v8::Number::New(env->isolate(), value)).IsEmpty();
+  });
+}
+
+inline void HistogramBase::HistogramReset(
+    const v8::FunctionCallbackInfo<v8::Value>& args) {
+  HistogramBase* histogram;
+  ASSIGN_OR_RETURN_UNWRAP(&histogram, args.Holder());
+  histogram->ResetState();
+}
+
+inline void HistogramBase::Initialize(Environment* env) {
+  // Guard against multiple initializations
+  if (!env->histogram_ctor_template().IsEmpty())
+    return;
+
+  v8::Local<v8::String> classname =
+      FIXED_ONE_BYTE_STRING(env->isolate(), "Histogram");
+
+  v8::Local<v8::FunctionTemplate> histogram =
+    v8::FunctionTemplate::New(env->isolate());
+  histogram->SetClassName(classname);
+
+  v8::Local<v8::ObjectTemplate> histogramt =
+    histogram->InstanceTemplate();
+
+  histogramt->SetInternalFieldCount(1);
+  env->SetProtoMethod(histogram, "exceeds", HistogramExceeds);
+  env->SetProtoMethod(histogram, "min", HistogramMin);
+  env->SetProtoMethod(histogram, "max", HistogramMax);
+  env->SetProtoMethod(histogram, "mean", HistogramMean);
+  env->SetProtoMethod(histogram, "stddev", HistogramStddev);
+  env->SetProtoMethod(histogram, "percentile", HistogramPercentile);
+  env->SetProtoMethod(histogram, "percentiles", HistogramPercentiles);
+  env->SetProtoMethod(histogram, "reset", HistogramReset);
+
+  env->set_histogram_ctor_template(histogramt);
+}
+
+inline HistogramBase* HistogramBase::New(
+    Environment* env,
+    int64_t lowest,
+    int64_t highest,
+    int figures) {
+  CHECK_LE(lowest, highest);
+  CHECK_GT(figures, 0);
+  v8::Local<v8::Object> obj;
+  auto tmpl = env->histogram_ctor_template();
+  if (!tmpl->NewInstance(env->context()).ToLocal(&obj))
+    return nullptr;
+
+  return new HistogramBase(env, obj, lowest, highest, figures);
 }
 
 }  // namespace node

--- a/src/histogram.h
+++ b/src/histogram.h
@@ -3,6 +3,7 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
+#include "base_object.h"
 #include "hdr_histogram.h"
 #include <functional>
 #include <map>
@@ -29,6 +30,71 @@ class Histogram {
 
  private:
   hdr_histogram* histogram_;
+};
+
+class HistogramBase : public BaseObject, public Histogram {
+ public:
+  inline HistogramBase(
+      Environment* env,
+      v8::Local<v8::Object> wrap,
+      int64_t lowest,
+      int64_t highest,
+      int figures = 3);
+
+  inline virtual ~HistogramBase() {}
+
+  inline virtual void TraceDelta(int64_t delta) {}
+
+  inline virtual void TraceExceeds(int64_t delta) {}
+
+  inline bool RecordDelta();
+
+  inline void ResetState();
+
+  inline int64_t Exceeds() { return exceeds_; }
+
+  inline void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackFieldWithSize("histogram", GetMemorySize());
+  }
+
+  SET_MEMORY_INFO_NAME(HistogramBase)
+  SET_SELF_SIZE(HistogramBase)
+
+  static inline void HistogramMin(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  static inline void HistogramMax(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  static inline void HistogramMean(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  static inline void HistogramExceeds(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  static inline void HistogramStddev(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  static inline void HistogramPercentile(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  static inline void HistogramPercentiles(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  static inline void HistogramReset(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  static inline void Initialize(Environment* env);
+
+  static inline HistogramBase* New(
+      Environment* env,
+      int64_t lowest,
+      int64_t highest,
+      int figures = 3);
+
+ private:
+  int64_t exceeds_ = 0;
+  uint64_t prev_ = 0;
 };
 
 }  // namespace node

--- a/src/node_quic.cc
+++ b/src/node_quic.cc
@@ -1,6 +1,7 @@
 #include "debug_utils.h"
 #include "node.h"
 #include "env-inl.h"
+#include "histogram-inl.h"
 #include "node_crypto.h"  // SecureContext
 #include "node_process.h"
 #include "node_quic_crypto.h"
@@ -174,6 +175,8 @@ void Initialize(Local<Object> target,
   Environment* env = Environment::GetCurrent(context);
   Isolate* isolate = env->isolate();
   HandleScope scope(isolate);
+
+  HistogramBase::Initialize(env);
 
   std::unique_ptr<QuicState> state(new QuicState(isolate));
 #define SET_STATE_TYPEDARRAY(name, field)             \

--- a/src/node_quic_session.h
+++ b/src/node_quic_session.h
@@ -921,13 +921,13 @@ class QuicSession : public AsyncWrap,
   // crypto_rx_ack_ measures the elapsed time between crypto acks
   // for this stream. This data can be used to detect peers that are
   // generally taking too long to acknowledge crypto data.
-  Histogram crypto_rx_ack_;
+  std::unique_ptr<HistogramBase> crypto_rx_ack_;
 
   // crypto_handshake_rate_ measures the elapsed time between
   // crypto continuation steps. This data can be used to detect
   // peers that are generally taking too long to carry out the
   // handshake
-  Histogram crypto_handshake_rate_;
+  std::unique_ptr<HistogramBase> crypto_handshake_rate_;
 
   struct recovery_stats {
     double min_rtt;

--- a/src/node_quic_stream.h
+++ b/src/node_quic_stream.h
@@ -392,7 +392,7 @@ class QuicStream : public AsyncWrap,
   // for the stream. Specifically, this can be used to detect
   // potentially bad acting peers that are sending many small chunks
   // of data too slowly in an attempt to DOS the peer.
-  Histogram data_rx_rate_;
+  std::unique_ptr<HistogramBase> data_rx_rate_;
 
   // data_rx_size_ measures the size of data packets for this stream
   // over time. When used in combination with the data_rx_rate_,
@@ -400,12 +400,12 @@ class QuicStream : public AsyncWrap,
   // for the stream. Specifically, this can be used to detect
   // potentially bad acting peers that are sending many small chunks
   // of data too slowly in an attempt to DOS the peer.
-  Histogram data_rx_size_;
+  std::unique_ptr<HistogramBase> data_rx_size_;
 
   // data_rx_ack_ measures the elapsed time between data acks
   // for this stream. This data can be used to detect peers that are
   // generally taking too long to acknowledge sent stream data.
-  Histogram data_rx_ack_;
+  std::unique_ptr<HistogramBase> data_rx_ack_;
 
   AliasedBigUint64Array stats_buffer_;
 };


### PR DESCRIPTION
This is largely experimental still. The idea is to expose received data
transmission rate and frame size statistics to make it easier for user
code to detect malicious or sub-optimal connections. We will need to
iterate on the approach here until we settle on the most useful.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
