### PR TITLE
quic: implement SERVER_BUSY

### DIFF
--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -1015,6 +1015,19 @@ decremented to `0` by a router, it will not be forwarded.
 The argument passed to `socket.setMulticastTTL()` is a number of hops between
 `0` and `255`. The default on most systems is `1` but can vary.
 
+### quicsocket.setServerBusy([on = true])
+<!-- YAML
+added: REPLACEME
+-->
+
+* `on` {boolean} When `true`, the `QuicSocket` will reject new connections.
+  **Defaults**: `true`.
+
+Calling `setServerBusy()` or `setServerBusy(true)` will tell the `QuicSocket`
+to reject all new incoming connection requests using the `SERVER_BUSY` QUIC
+error code. To begin receiving connections again, disable busy mode by calling
+`setServerBusy(false)`.
+
 ### quicsocket.setTTL(ttl)
 <!-- YAML
 added: REPLACEME

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -1200,22 +1200,15 @@ class QuicSocket extends EventEmitter {
     return this;
   }
 
-  // TODO(@jasnell): Marking a server as busy will cause all new
+  // Marking a server as busy will cause all new
   // connection attempts to fail with a SERVER_BUSY CONNECTION_CLOSE.
-  // Unfortunately, however, ngtcp2 does not yet support writing a
-  // CONNECTION_CLOSE in an initial packet as required by the
-  // specification so we can't enable this yet. The basic mechanism
-  // has been implemented but we can't expose it yet.
-  //
-  // Once enabled, uncomment the following to expose the API
-  //
-  // setServerBusy(on = true) {
-  //   if (this.#state === kSocketDestroyed)
-  //     throw new ERR_QUIC_SOCKETDESTROYED('setBroadcast');
-  //   if (typeof on !== 'boolean')
-  //     throw new ERR_INVALID_ARG_TYPE('on', 'boolean', on);
-  //   this[kHandle].setServerBusy(on);
-  // }
+  setServerBusy(on = true) {
+    if (this.#state === kSocketDestroyed)
+      throw new ERR_QUIC_SOCKETDESTROYED('setBroadcast');
+    if (typeof on !== 'boolean')
+      throw new ERR_INVALID_ARG_TYPE('on', 'boolean', on);
+    this[kHandle].setServerBusy(on);
+  }
 
   get duration() {
     const now = process.hrtime.bigint();

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -257,7 +257,7 @@ function onSessionClose(code, family) {
   // session will enter the closing period, after which it will
   // be destroyed either when the idle timeout expires, the
   // QuicSession is silently closed, or destroy is called.
-  this[owner_symbol][kClose](code, family);
+  this[owner_symbol][kClose](family, code);
 }
 
 // This callback is invoked at the start of the TLS handshake to provide
@@ -1342,7 +1342,7 @@ class QuicSession extends EventEmitter {
               supportedVersions);
   }
 
-  [kClose](code, family) {
+  [kClose](family, code) {
     // Immediate close has been initiated for the session. Any
     // still open QuicStreams must be abandoned and shutdown
     // with RESET_STREAM and STOP_SENDING frames transmitted
@@ -1360,13 +1360,13 @@ class QuicSession extends EventEmitter {
 
     // Shutdown all of the remaining streams
     for (const stream of this.#streams.values())
-      stream[kClose](code, family);
+      stream[kClose](family, code);
 
     // By this point, all necessary RESET_STREAM and
     // STOP_SENDING frames ought to have been sent,
     // so now we just trigger sending of the
     // CONNECTION_CLOSE frame.
-    this[kHandle].close(code, family);
+    this[kHandle].close(family, code);
   }
 
   [kStreamClose](id, code) {
@@ -2101,7 +2101,7 @@ class QuicStream extends Duplex {
     this.read();
   }
 
-  [kClose](code, family) {
+  [kClose](family, code) {
     // Trigger the abrupt shutdown of the stream. If the stream is
     // already no-longer readable or writable, this does nothing. If
     // the stream is readable or writable, then the abort event will
@@ -2262,7 +2262,7 @@ class QuicStream extends Duplex {
   }
 
   close(code) {
-    this[kClose](code, QUIC_ERROR_APPLICATION);
+    this[kClose](QUIC_ERROR_APPLICATION, code);
   }
 
   get session() {

--- a/src/node_quic_session.h
+++ b/src/node_quic_session.h
@@ -190,7 +190,8 @@ class QuicSession : public AsyncWrap,
       // to the HTTP/3 identifier. For QUIC, the alpn identifier
       // is always required.
       const std::string& alpn,
-      uint32_t options = 0);
+      uint32_t options = 0,
+      uint64_t initial_connection_close = NGTCP2_NO_ERROR);
   ~QuicSession() override;
 
   std::string diagnostic_name() const override;
@@ -820,6 +821,7 @@ class QuicSession : public AsyncWrap,
 
   QuicSessionType type_;
 
+  uint64_t initial_connection_close_;
   ngtcp2_crypto_level rx_crypto_level_;
   ngtcp2_crypto_level tx_crypto_level_;
   QuicError last_error_;
@@ -1029,7 +1031,8 @@ class QuicServerSession : public QuicSession {
       const ngtcp2_cid* ocid,
       uint32_t version,
       const std::string& alpn = NGTCP2_ALPN_H3,
-      uint32_t options = 0);
+      uint32_t options = 0,
+      uint64_t initial_connection_close = NGTCP2_NO_ERROR);
 
   void AddToSocket(QuicSocket* socket) override;
   void Init(
@@ -1067,7 +1070,8 @@ class QuicServerSession : public QuicSession {
       const ngtcp2_cid* ocid,
       uint32_t version,
       const std::string& alpn,
-      uint32_t options);
+      uint32_t options,
+      uint64_t initial_connection_close);
 
   void DisassociateCID(const ngtcp2_cid* cid) override;
   void InitTLS_Post() override;


### PR DESCRIPTION
Initial server busy handling. Unfortunately there's going to be
a little bit of overhead when rejecting a connection because we
have to install the keys, but we need to attempt to minimize it.

Should explore how to minimize it further. Maybe we should have
a special QuicSession specialization that only handles rejections?


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
