### PR TITLE
quic: start improving connection close reporting

### DIFF
--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -435,12 +435,12 @@ function onStreamError(streamHandle, error) {
   streamHandle[owner_symbol].destroy(error);
 }
 
-function onSessionSilentClose() {
+function onSessionSilentClose(code, family) {
   // During a silent close, all currently open QuicStreams are abruptly
   // closed. If they are still writable or readable, an abort event will be
   // emitted, otherwise the stream is just destroyed. No RESET_STREAM or
   // STOP_SENDING is transmitted to the peer.
-  this[owner_symbol].destroy();
+  this[owner_symbol][kDestroy](family, code);
 }
 
 // Register the callbacks with the QUIC internal binding.
@@ -1340,6 +1340,14 @@ class QuicSession extends EventEmitter {
               version,
               requestedVersions,
               supportedVersions);
+  }
+
+  [kDestroy](family, code) {
+    if (this.#destroyed)
+      return;
+    this.#closeCode = code;
+    this.#closeFamily = family;
+    this.destroy();
   }
 
   [kClose](family, code) {


### PR DESCRIPTION
There's still a limitation in that ngtcp2 does not yet appear
to provide access to the connection_close error code so this is only a partial solution to https://github.com/nodejs/quic/issues/86. Once I figure out how to get access to the connection_close error code I will open a PR to propagate it up.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
