### PR TITLE
quic: use std::shared_ptr for AddStream

### DIFF
--- a/src/node_quic_session.cc
+++ b/src/node_quic_session.cc
@@ -332,7 +332,7 @@ void QuicSession::AckedStreamDataOffset(
 
 // Add the given QuicStream to this QuicSession's collection of streams. All
 // streams added must be removed before the QuicSession instance is freed.
-void QuicSession::AddStream(QuicStream* stream) {
+void QuicSession::AddStream(std::shared_ptr<QuicStream> stream) {
   DCHECK(!IsFlagSet(QUICSESSION_FLAG_GRACEFUL_CLOSING));
   Debug(this, "Adding stream %" PRId64 " to session.", stream->GetID());
   streams_.emplace(stream->GetID(), stream);
@@ -412,7 +412,7 @@ QuicStream* QuicSession::CreateStream(int64_t stream_id) {
   CHECK(!IsFlagSet(QUICSESSION_FLAG_GRACEFUL_CLOSING));
   CHECK(!IsFlagSet(QUICSESSION_FLAG_CLOSING));
 
-  QuicStream* stream = QuicStream::New(this, stream_id);
+  std::shared_ptr<QuicStream> stream = QuicStream::New(this, stream_id);
   CHECK_NOT_NULL(stream);
   Local<Value> argv[] = {
     stream->object(),
@@ -423,7 +423,7 @@ QuicStream* QuicSession::CreateStream(int64_t stream_id) {
   // from being freed while the MakeCallback is running.
   std::shared_ptr<QuicSession> ptr(shared_from_this());
   MakeCallback(env()->quic_on_stream_ready_function(), arraysize(argv), argv);
-  return stream;
+  return stream.get();
 }
 
 // Mark the QuicSession instance destroyed. After this is called,

--- a/src/node_quic_session.h
+++ b/src/node_quic_session.h
@@ -246,7 +246,7 @@ class QuicSession : public AsyncWrap,
 
   ngtcp2_conn* Connection() { return connection_.get(); }
 
-  void AddStream(QuicStream* stream);
+  void AddStream(std::shared_ptr<QuicStream> stream);
 
   // Immediately discards the state of the QuicSession
   // and renders the QuicSession instance completely

--- a/src/node_quic_stream.h
+++ b/src/node_quic_stream.h
@@ -144,7 +144,8 @@ class QuicStream : public AsyncWrap,
       v8::Local<v8::Object> target,
       v8::Local<v8::Context> context);
 
-  static QuicStream* New(QuicSession* session, int64_t stream_id);
+  static std::shared_ptr<QuicStream> New(
+      QuicSession* session, int64_t stream_id);
 
   std::string diagnostic_name() const override;
 


### PR DESCRIPTION
This is based on https://github.com/nodejs/quic/issues/39#issuecomment-535014207. Note that I’ll probably work more on this in the near future and that that might actually mean moving away from `std::shared_ptr` and figuring out a better solution (and maybe one that also works well for HTTP/2 where we’ve had similar issues), because currently it’s pretty easy to crash the process during cleanup because ownership of objects is conflictingly both managed through `std::shared_ptr`s and through the association with JS objects.

---

We stored the argument as a shared_ptr in the `streams_` map,
and `QuicStream`s are managed through shared_ptr instances,
so this method should use a shared_ptr argument as well.

This requires moving the `AddStream()` call to until after
the object construction is finished.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
