### PR TITLE
quic: do not leak memory when UDP sending fails

### DIFF
--- a/src/node_quic_socket.cc
+++ b/src/node_quic_socket.cc
@@ -512,7 +512,7 @@ void QuicSocket::SendInitialConnectionClose(
 
   if (nwrite > 0) {
     req->SetLength(nwrite);
-    req->Send();
+    if (req->Send() != 0) delete req;  // TODO(addaleax): Better error handling?
   }
 }
 
@@ -548,7 +548,7 @@ void QuicSocket::SendVersionNegotiation(
   if (nwrite < 0)
     return;
   req->SetLength(nwrite);
-  req->Send();
+  if (req->Send() != 0) delete req;  // TODO(addaleax): Better error handling?
 }
 
 ssize_t QuicSocket::SendRetry(
@@ -599,7 +599,9 @@ ssize_t QuicSocket::SendRetry(
     return nwrite;
   req->SetLength(nwrite);
 
-  return req->Send();
+  int err = req->Send();
+  if (err != 0) delete req;
+  return err;
 }
 
 namespace {
@@ -821,7 +823,9 @@ int QuicSocket::SendPacket(
           buffer,
           session,
           diagnostic_label);
-  return wrap->Send();
+  int err = wrap->Send();
+  if (err != 0) delete wrap;
+  return err;
 }
 
 void QuicSocket::OnSend(


### PR DESCRIPTION
Destroy `SendWrap` instances that are not destroyed through the
usual path because sending failed.

There should possibly be error handling for some of
those failure conditions, too.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
