### PR TITLE
quic: manage event loop request counter for `QuicSocket::SendWrap`s

### DIFF
--- a/src/node_quic_socket.cc
+++ b/src/node_quic_socket.cc
@@ -873,6 +873,7 @@ bool QuicSocket::SendWrapBase::IsDiagnosticPacketLoss() {
 }
 
 void QuicSocket::SendWrapBase::Done(int status) {
+  socket_->env()->DecreaseWaitingRequestCounter();
   socket_->OnSend(status, Length(), diagnostic_label());
 }
 
@@ -901,12 +902,16 @@ int QuicSocket::SendWrapStack::Send() {
           reinterpret_cast<char*>(*buf_),
           buf_.length());
 
-  return uv_udp_send(
+  int err = uv_udp_send(
       req(),
       &Socket()->handle_,
       &buf, 1,
       **Address(),
       OnSend);
+  // As this does not inherit from ReqWrap, we have to manage the request
+  // counter manually.
+  if (err == 0) Socket()->env()->IncreaseWaitingRequestCounter();
+  return err;
 }
 
 // The QuicSocket::SendWrap will maintain a std::weak_ref
@@ -977,6 +982,9 @@ int QuicSocket::SendWrap::Send() {
       OnSend);
 
   if (err == 0) {
+    // As this does not inherit from ReqWrap, we have to manage the request
+    // counter manually.
+    Socket()->env()->IncreaseWaitingRequestCounter();
     Debug(Socket(), "Advancing read head %" PRIu64, length_);
     buffer_->SeekHeadOffset(length_);
   }


### PR DESCRIPTION
As we don’t use `ReqWrap` like elsewhere in the code base, we need
to manage the counter manually as a way to make sure that the
Environment exists for as long as necessary when shutting down while
a `SendWrap` is in progress.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
