### PR TITLE
quic: remove memcmp before memcpy

### DIFF
--- a/src/node_quic_util.h
+++ b/src/node_quic_util.h
@@ -267,26 +267,23 @@ class SocketAddress {
   }
 
   void Copy(SocketAddress* addr) {
-    if (memcmp(&address_, **addr, addr->Size()) != 0)
-      memcpy(&address_, **addr, addr->Size());
+    Copy(**addr);
   }
 
   void Copy(const sockaddr* source) {
-    if (memcmp(&address_, source, GetAddressLen(source)) != 0)
-      memcpy(&address_, source, GetAddressLen(source));
+    memcpy(&address_, source, GetAddressLen(source));
   }
 
   void Set(uv_udp_t* handle) {
     int addrlen = sizeof(address_);
     CHECK_EQ(uv_udp_getsockname(
-      handle,
-      reinterpret_cast<sockaddr*  >(&address_),
-      &addrlen), 0);
+        handle,
+        reinterpret_cast<sockaddr*>(&address_),
+        &addrlen), 0);
   }
 
   void Update(const ngtcp2_addr* addr) {
-    if (memcmp(&address_, addr->addr, addr->addrlen) != 0)
-      memcpy(&address_, addr->addr, addr->addrlen);
+    memcpy(&address_, addr->addr, addr->addrlen);
   }
 
   const sockaddr* operator*() const {


### PR DESCRIPTION
This pattern is equivalent to just performing memcpy.
The previous code would be reported as access to uninitialized
memory by e.g. valgrind.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
