### PR TITLE
quic: fixup line break in ngtcp2debuglog

### DIFF
--- a/src/node_quic_session.cc
+++ b/src/node_quic_session.cc
@@ -21,6 +21,7 @@
 
 #include <array>
 #include <functional>
+#include <string>
 #include <type_traits>
 #include <utility>
 
@@ -54,7 +55,9 @@ static void Ngtcp2DebugLog(void* user_data, const char* fmt, ...) {
   QuicSession* session = static_cast<QuicSession*>(user_data);
   va_list ap;
   va_start(ap, fmt);
-  Debug(session->env(), DebugCategory::NGTCP2_DEBUG, fmt, ap);
+  std::string format(fmt, strlen(fmt) + 1);
+  format[strlen(fmt)] = '\n';
+  Debug(session->env(), DebugCategory::NGTCP2_DEBUG, format, ap);
   va_end(ap);
 }
 


### PR DESCRIPTION
new lines at the end of the debug statement weren't being added.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
