### PR TITLE
quic: fix the misuse of uv_inet_ntop

### DIFF
--- a/src/node_quic_util.h
+++ b/src/node_quic_util.h
@@ -200,7 +200,7 @@ class SocketAddress {
     }
 
     char host[NI_MAXHOST];
-    if (uv_inet_ntop(af, binaddr, host, sizeof(host)) == 0)
+    if (uv_inet_ntop(af, binaddr, host, sizeof(host)) != 0)
       return false;
 
     addrinfo hints{};


### PR DESCRIPTION
The return value of `uv_inet_ntop` means success when it's zero.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
