### PR TITLE
quic: fix early QuicSocket.close issue

### DIFF
--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -199,12 +199,11 @@ added: REPLACEME
 
 Information about the cipher algorithm selected for the session.
 
-### quicsession.close([code[, callback]])
+### quicsession.close([callback])
 <!-- YAML
 added: REPLACEME
 -->
 
-* `code` {number} The error code to when closing the session. Default: `0`.
 * `callback` {Function} Callback invoked when the close operation is completed
 
 Begins a graceful close of the `QuicSession`. Existing `QuicStream` instances

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -997,7 +997,6 @@ class QuicSocket extends EventEmitter {
     // port, destroy the QuicSocket immediately.
     if (this.#state !== kSocketBound) {
       this.destroy();
-      callback();
     }
 
     // Mark the QuicSocket as closing to prevent re-entry
@@ -1011,7 +1010,9 @@ class QuicSocket extends EventEmitter {
     // listening for new QuicServerSession connections.
     // New initial connection packets for currently unknown
     // DCID's will be ignored.
-    this[kHandle].stopListening();
+    if (this[kHandle]) {
+      this[kHandle].stopListening();
+    }
     this.#serverListening = false;
 
     // If there are no sessions, calling maybeDestroy

--- a/test/parallel/test-quic-socket-close.js
+++ b/test/parallel/test-quic-socket-close.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasQuic)
+  common.skip('missing quic');
+
+const assert = require('assert');
+const { createSocket } = require('quic');
+
+const kClientPort = process.env.NODE_DEBUG_KEYLOG ? 5679 : 0;
+
+{
+  const socket = createSocket({
+    port: kClientPort,
+  });
+  socket.close();
+  assert.throws(() => socket.close(), {
+    code: 'ERR_QUICSOCKET_DESTROYED',
+    name: 'Error',
+    message: 'Cannot call close after a QuicSocket has been destroyed'
+  });
+}
+
+{
+  const socket = createSocket({
+    port: kClientPort,
+  });
+
+  socket.close(common.mustCall(() => {}));
+}


### PR DESCRIPTION
This PR makes sure that:
- the callback of `QuicSocket.close()` will only be called once
- `QuicSocket.close()` won't throw for not being bound

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
