### PR TITLE
quic: refactor transport_params usage

### DIFF
--- a/src/node_quic_session.cc
+++ b/src/node_quic_session.cc
@@ -2633,12 +2633,11 @@ int QuicClientSession::SetSession(SSL_SESSION* session) {
   if (!session_ticket.empty())
     argv[1] = session_ticket.ToBuffer().ToLocalChecked();
 
-  if (transportParams_.length() > 0) {
-    argv[2] = Buffer::New(
+  if (has_transport_params_) {
+    argv[2] = Buffer::Copy(
         env(),
-        *transportParams_,
-        transportParams_.length(),
-        [](char* data, void* hint) {}, nullptr).ToLocalChecked();
+        reinterpret_cast<const char*>(&transport_params_),
+        sizeof(transport_params_)).ToLocalChecked();
   }
   // Grab a shared pointer to this to prevent the QuicSession
   // from being freed while the MakeCallback is running.
@@ -2686,8 +2685,8 @@ bool QuicClientSession::SetSocket(QuicSocket* socket, bool nat_rebinding) {
 void QuicClientSession::StoreRemoteTransportParams(
     ngtcp2_transport_params* params) {
   CHECK(!IsFlagSet(QUICSESSION_FLAG_DESTROYED));
-  transportParams_.AllocateSufficientStorage(sizeof(ngtcp2_transport_params));
-  memcpy(*transportParams_, params, sizeof(ngtcp2_transport_params));
+  transport_params_ = *params;
+  has_transport_params_ = true;
 }
 
 void QuicClientSession::InitTLS_Post() {

--- a/src/node_quic_session.h
+++ b/src/node_quic_session.h
@@ -1222,7 +1222,8 @@ class QuicClientSession : public QuicSession {
   SelectPreferredAddressPolicy select_preferred_address_policy_;
   std::string hostname_;
 
-  MaybeStackBuffer<char> transportParams_;
+  ngtcp2_transport_params transport_params_;
+  bool has_transport_params_;
 
 
   static const ngtcp2_conn_callbacks callbacks;


### PR DESCRIPTION
- Use `Buffer::Copy()` to avoid use-after-free crashes.
- Store the struct directly to save memory, as opposed to using
  the (by default larger) `MaybeStackBuffer`.

It is somewhat unclear to me whether the field will be used after
emitting it through the `sessionTicket`, e.g. through multiple
`.setSession()` calls. If not, this could be further reduced to
an `AllocatedBuffer` from which we create the Buffer instance.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
