### PR TITLE
src,lib,test: make tests mostly pass

### DIFF
--- a/lib/internal/stream_base_commons.js
+++ b/lib/internal/stream_base_commons.js
@@ -149,7 +149,7 @@ function afterWriteDispatched(self, req, err) {
   if (err !== 0)
     return self.destroy(
       errnoException(err, 'write', req.error),
-      req.callback());
+      req.callback);
 
   if (!req.async && typeof req.callback === 'function') {
     req.callback();

--- a/src/base_object-inl.h
+++ b/src/base_object-inl.h
@@ -187,7 +187,7 @@ void BaseObject::decrease_refcount() {
   if (new_refcount == 0) {
     if (metadata->is_detached) {
       delete this;
-    } else if (metadata->wants_weak_jsobj) {
+    } else if (metadata->wants_weak_jsobj && !persistent_handle_.IsEmpty()) {
       MakeWeak();
     }
   }
@@ -195,7 +195,7 @@ void BaseObject::decrease_refcount() {
 
 void BaseObject::increase_refcount() {
   unsigned int prev_refcount = pointer_data()->strong_ptr_count++;
-  if (prev_refcount == 0)
+  if (prev_refcount == 0 && !persistent_handle_.IsEmpty())
     persistent_handle_.ClearWeak();
 }
 

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -11,14 +11,12 @@ const expected_keys = [
   'v8',
   'zlib',
   'nghttp2',
-  'nghttp3',
   'napi',
   'llhttp'
 ];
 
 if (common.hasCrypto) {
   expected_keys.push('openssl');
-  expected_keys.push('ngtcp2');
 }
 
 if (common.hasIntl) {
@@ -26,6 +24,11 @@ if (common.hasIntl) {
   expected_keys.push('cldr');
   expected_keys.push('tz');
   expected_keys.push('unicode');
+}
+
+if (common.hasQuic) {
+  expected_keys.push('ngtcp2');
+  expected_keys.push('nghttp3');
 }
 
 expected_keys.sort();


### PR DESCRIPTION
Make the test mostly pass, with and without `./configure --experimental-quic`. This does not fix a code cache test, which seems to be broken with and without the flag.