### PR TITLE
quic: client should work when receives invalid preferred address

### DIFF
--- a/src/node_quic_util.h
+++ b/src/node_quic_util.h
@@ -200,7 +200,7 @@ class SocketAddress {
     }
 
     char host[NI_MAXHOST];
-    if (uv_inet_ntop(af, binaddr, host, sizeof(host)) == 0)
+    if (uv_inet_ntop(af, binaddr, host, sizeof(host)) != 0)
       return false;
 
     addrinfo hints{};

--- a/test/parallel/test-quic-client-empty-preferred-address.js
+++ b/test/parallel/test-quic-client-empty-preferred-address.js
@@ -1,0 +1,66 @@
+'use strict';
+
+// This test ensures that when we don't define `preferredAddress`
+// on the server while the `preferredAddressPolicy` on the client
+// is `accpet`, it works as expected.
+
+const common = require('../common');
+if (!common.hasQuic)
+  common.skip('missing quic');
+
+const assert = require('assert');
+const fixtures = require('../common/fixtures');
+const key = fixtures.readKey('agent1-key.pem', 'binary');
+const cert = fixtures.readKey('agent1-cert.pem', 'binary');
+const ca = fixtures.readKey('ca1-cert.pem', 'binary');
+const { createSocket } = require('quic');
+
+const kALPN = 'zzz';
+const kServerName = 'agent2';
+const server = createSocket({ port: 0, validateAddress: true });
+
+let client;
+server.listen({
+  key,
+  cert,
+  ca,
+  alpn: kALPN,
+});
+
+server.on('session', common.mustCall((serverSession) => {
+  serverSession.on('stream', common.mustCall((stream) => {
+    stream.on('data', common.mustCall((data) => {
+      assert.strictEqual(data.toString('utf8'), 'hello');
+    }));
+    stream.on('end', common.mustCall(() => {
+      stream.close();
+      client.close();
+      server.close();
+    }));
+  }));
+}));
+
+server.on('ready', common.mustCall(() => {
+  client = createSocket({
+    port: 0,
+  });
+
+  const clientSession = client.connect({
+    address: 'localhost',
+    key,
+    cert,
+    ca,
+    alpn: kALPN,
+    port: server.address.port,
+    servername: kServerName,
+    preferredAddressPolicy: 'accept',
+  });
+
+  clientSession.on('close', common.mustCall());
+
+  clientSession.on('secure', common.mustCall(() => {
+    const stream = clientSession.openStream();
+    stream.end('hello');
+    stream.on('close', common.mustCall());
+  }));
+}));


### PR DESCRIPTION
If we set `preferredAddressPolicy` to `accept` on `QuicClientSession`
but receives an invalid preferred address, e.g. we don't define
`preferredAddress` on the server, the `QuicClientSession` should still
work. Before this PR, the included test will cause segmetation fault.

the example in `ngtcp2` always return 0 on `select_preferred_address `: https://github.com/ngtcp2/ngtcp2/blob/52d56a90a7766c71c68362dc85f5fdc866760f47/examples/client.cc#L673

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
