### PR TITLE
test: add tests for quic `idleTimeout`

### DIFF
--- a/test/parallel/test-quic-idle-timeout.js
+++ b/test/parallel/test-quic-idle-timeout.js
@@ -1,0 +1,101 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasQuic)
+  common.skip('missing quic');
+
+const assert = require('assert');
+const { createSocket } = require('quic');
+const fixtures = require('../common/fixtures');
+const key = fixtures.readKey('agent1-key.pem', 'binary');
+const cert = fixtures.readKey('agent1-cert.pem', 'binary');
+const ca = fixtures.readKey('ca1-cert.pem', 'binary');
+
+const kServerName = 'agent2';
+const kALPN = 'zzz';
+// Allow error for 500 milliseconds more.
+const error = common.platformTimeout(500);
+const idleTimeout = common.platformTimeout(1000);
+
+// Test client idle timeout.
+{
+  let client;
+  const server = createSocket({ port: 0 });
+  server.listen({
+    key,
+    cert,
+    ca,
+    alpn: kALPN,
+  });
+
+  server.on('session', common.mustCall());
+
+  server.on('ready', common.mustCall(() => {
+    client = createSocket({
+      port: 0,
+      client: {
+        key,
+        cert,
+        ca,
+        alpn: kALPN,
+      }
+    });
+
+    const start = Date.now();
+
+    const clientSession = client.connect({
+      address: 'localhost',
+      port: server.address.port,
+      servername: kServerName,
+      idleTimeout,
+    });
+
+    clientSession.on('close', common.mustCall(() => {
+      client.close();
+      server.close();
+      assert(Date.now() - start < idleTimeout + error);
+    }));
+  }));
+}
+
+// Test server idle timeout.
+{
+  let client;
+  let start;
+  const server = createSocket({ port: 0 });
+  server.listen({
+    key,
+    cert,
+    ca,
+    alpn: kALPN,
+    idleTimeout,
+  });
+
+  server.on('session', common.mustCall(() => {
+    client.close();
+    server.close();
+    assert(Date.now() - start < idleTimeout + error);
+  }));
+
+  server.on('ready', common.mustCall(() => {
+    client = createSocket({
+      port: 0,
+      client: {
+        key,
+        cert,
+        ca,
+        alpn: kALPN,
+      }
+    });
+
+
+    start = Date.now();
+    const clientSession = client.connect({
+      address: 'localhost',
+      port: server.address.port,
+      servername: kServerName,
+    });
+
+    clientSession.on('close', common.mustCall());
+  }));
+}


### PR DESCRIPTION
It would be better to add a test to ensure that the timeout is greater than the triple PTO if we can get the PTO.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
(https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
