### PR TITLE
quic: fix idle timeout

### DIFF
--- a/src/node_quic_session.cc
+++ b/src/node_quic_session.cc
@@ -1527,7 +1527,10 @@ void QuicSession::StreamReset(
 
 void QuicSession::UpdateIdleTimer() {
   CHECK_NOT_NULL(idle_);
-  uint64_t timeout = ngtcp2_conn_get_idle_expiry(Connection()) / 1000000UL;
+  uint64_t now = uv_hrtime();
+  uint64_t expiry = ngtcp2_conn_get_idle_expiry(Connection());
+  uint64_t timeout = (expiry - now) / 1000000UL;
+  if (expiry < now || timeout == 0) timeout = 1;
   Debug(this, "Updating idle timeout to %" PRIu64, timeout);
   idle_->Update(timeout);
 }

--- a/test/parallel/test-quic-idle-timeout.js
+++ b/test/parallel/test-quic-idle-timeout.js
@@ -71,10 +71,12 @@ const idleTimeout = common.platformTimeout(1000);
     idleTimeout,
   });
 
-  server.on('session', common.mustCall(() => {
-    client.close();
-    server.close();
-    assert(Date.now() - start < idleTimeout + error);
+  server.on('session', common.mustCall((serverSession) => {
+    serverSession.on('close', common.mustCall(() => {
+      client.close();
+      server.close();
+      assert(Date.now() - start < idleTimeout + error);
+    }));
   }));
 
   server.on('ready', common.mustCall(() => {


### PR DESCRIPTION
After ngtcp2 being updated, `ngtcp2_conn_get_idle_timeout` is renamed as
`ngtcp2_conn_get_idle_expiry` which returns `ngtcp2_tstamp` instead of
`ngtcp2_duration`.

Refs: https://github.com/ngtcp2/ngtcp2/blob/6f40668cdce7db7c043d3a80c07f379841d8c51e/lib/ngtcp2_conn.c#L8604

Fixes: #164 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
