### PR TITLE
quic: simplify alpn selection callback

### DIFF
--- a/src/node_quic_session.h
+++ b/src/node_quic_session.h
@@ -1000,6 +1000,7 @@ class QuicServerSession : public QuicSession {
 
   static InitialPacketResult Accept(
     ngtcp2_pkt_hd* hd,
+    uint32_t version,
     const uint8_t* data,
     ssize_t nread);
 

--- a/src/node_quic_socket.cc
+++ b/src/node_quic_socket.cc
@@ -655,7 +655,7 @@ BaseObjectPtr<QuicSession> QuicSocket::AcceptInitialPacket(
 
   // Perform some initial checks on the packet to see if it is an
   // acceptable initial packet with the right QUIC version.
-  switch (QuicServerSession::Accept(&hd, data, nread)) {
+  switch (QuicServerSession::Accept(&hd, version, data, nread)) {
     case QuicServerSession::InitialPacketResult::PACKET_VERSION:
       SendVersionNegotiation(version, dcid, scid, addr);
       // Fall through


### PR DESCRIPTION
Refinements to alpn selection. Next step will be to error if the alpn selection was not successful