### PR TITLE
test: add tests for quic `ipv6Only`

### DIFF
--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -84,6 +84,7 @@ added: REPLACEME
     recently validated addresses are remembered. Setting `validateAddressLRU`
     to `true`, will enable the `validateAddress` option as well. Default:
     `false`.
+  * `ipv6Only` {boolean}
 
 Creates a new `QuicSocket` instance.
 
@@ -1118,8 +1119,8 @@ added: REPLACEME
   * `length` {number} The amount of data from the fd to send.
     Default: `-1`.
 
-Instead of using a `Quicstream` as a writable stream, send data from a given file
-descriptor.
+Instead of using a `Quicstream` as a writable stream, send data from a given
+file descriptor.
 
 If `offset` is set to a non-negative number, reading starts from that position
 and the file offset will not be advanced.
@@ -1146,8 +1147,8 @@ added: REPLACEME
   * `length` {number} The amount of data from the fd to send.
     Default: `-1`.
 
-Instead of using a `QuicStream` as a writable stream, send data from a given file
-path.
+Instead of using a `QuicStream` as a writable stream, send data from a given
+file path.
 
 The `options.onError` callback will be called if the file could not be opened.
 If `offset` is set to a non-negative number, reading starts from that position.

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -21,7 +21,6 @@ const {
   validateQuicClientSessionOptions,
   validateQuicSocketOptions,
 } = require('internal/quic/util');
-const { validateNumber } = require('internal/validators');
 const util = require('util');
 const assert = require('internal/assert');
 const EventEmitter = require('events');

--- a/test/parallel/test-quic-ipv6only.js
+++ b/test/parallel/test-quic-ipv6only.js
@@ -1,0 +1,132 @@
+'use strict';
+
+// TODO support ipv6
+const common = require('../common');
+if (!common.hasQuic)
+  common.skip('missing quic');
+
+const { createSocket } = require('quic');
+const fixtures = require('../common/fixtures');
+const key = fixtures.readKey('agent1-key.pem', 'binary');
+const cert = fixtures.readKey('agent1-cert.pem', 'binary');
+const ca = fixtures.readKey('ca1-cert.pem', 'binary');
+
+const kServerName = 'agent2';
+const kALPN = 'zzz';
+
+// Setting `type` to `udp4` while setting `ipv6Only` to `true` is possible
+// and it will throw an error.
+{
+  const server = createSocket({
+    type: 'udp4',
+    port: 0,
+    ipv6Only: true,
+  });
+
+  server.on('error', common.mustCall((err) => {
+    common.expectsError({
+      code: 'EINVAL',
+      type: Error,
+      // TODO(@oyyd): Currently we can't know the exact "syscall" so that it's
+      // undefined here.
+      message: 'undefined EINVAL',
+    })(err);
+  }));
+
+  server.listen({
+    key,
+    cert,
+    ca,
+    alpn: kALPN,
+  });
+}
+
+// Connecting ipv6 server by "127.0.0.1" should work when `ipv6Only`
+// is set to `false`.
+{
+  const server = createSocket({
+    type: 'udp6',
+    port: 0,
+    ipv6Only: false,
+  });
+
+  server.listen({
+    key,
+    cert,
+    ca,
+    alpn: kALPN,
+  });
+
+  server.on('session', common.mustCall((serverSession) => {
+    serverSession.on('stream', common.mustCall());
+  }));
+
+  server.on('ready', common.mustCall(() => {
+    const client = createSocket({
+      port: 0,
+    });
+
+    const clientSession = client.connect({
+      key,
+      cert,
+      ca,
+      address: common.localhostIPv4,
+      port: server.address.port,
+      servername: kServerName,
+      alpn: kALPN,
+    });
+
+    clientSession.on('secure', common.mustCall(() => {
+      const clientStream = clientSession.openStream({
+        halfOpen: true,
+      });
+      clientStream.end('hello');
+      clientStream.on('close', common.mustCall(() => {
+        client.close();
+        server.close();
+      }));
+    }));
+  }));
+}
+
+// When the `ipv6Only` set to `true`, a client cann't connect to it
+// through "127.0.0.1".
+{
+  const server = createSocket({
+    type: 'udp6',
+    port: 0,
+    ipv6Only: true,
+  });
+
+  server.listen({
+    key,
+    cert,
+    ca,
+    alpn: kALPN,
+  });
+
+  server.on('ready', common.mustCall(() => {
+    const client = createSocket({
+      port: 0,
+    });
+
+    client.on('ready', common.mustCall());
+
+    const clientSession = client.connect({
+      key,
+      cert,
+      ca,
+      address: common.localhostIPv4,
+      port: server.address.port,
+      servername: kServerName,
+      alpn: kALPN,
+      idleTimeout: common.platformTimeout(500),
+    });
+
+    clientSession.on('secure', common.mustNotCall());
+    clientSession.on('close', common.mustCall(() => {
+      client.close();
+      server.close();
+    }));
+  }));
+}


### PR DESCRIPTION
Also fix some lint issues.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
