### PR TITLE
quic: rename shutdown to reset for RESET_STREAM methods

### DIFF
--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -2159,7 +2159,7 @@ class QuicStream extends Duplex {
     // as appropriate. Notify ngtcp2 that the stream is to be shutdown.
     // Once sent, the stream will be closed and destroyed as soon as
     // the shutdown is acknowledged by the peer.
-    this[kHandle].shutdownStream(code, family);
+    this[kHandle].resetStream(code, family);
 
     // Close down the readable side of the stream
     if (this.readable) {

--- a/src/node_quic_default_application.cc
+++ b/src/node_quic_default_application.cc
@@ -37,7 +37,7 @@ bool DefaultApplication::ReceiveStreamData(
   if (stream == nullptr) {
     // Shutdown the stream explicitly if the session is being closed.
     if (Session()->IsGracefullyClosing()) {
-      Session()->ShutdownStream(stream_id, NGTCP2_ERR_CLOSING);
+      Session()->ResetStream(stream_id, NGTCP2_ERR_CLOSING);
       return true;
     }
 

--- a/src/node_quic_http3_application.cc
+++ b/src/node_quic_http3_application.cc
@@ -513,7 +513,7 @@ void Http3Application::H3CancelPush(
 void Http3Application::H3SendStopSending(
     int64_t stream_id,
     uint64_t app_error_code) {
-  Session()->ShutdownStream(stream_id, app_error_code);
+  Session()->ResetStream(stream_id, app_error_code);
 }
 
 int Http3Application::H3PushStream(

--- a/src/node_quic_session.cc
+++ b/src/node_quic_session.cc
@@ -1952,7 +1952,7 @@ bool QuicSession::SetSocket(QuicSocket* socket, bool nat_rebinding) {
   return true;
 }
 
-void QuicSession::ShutdownStream(int64_t stream_id, uint64_t code) {
+void QuicSession::ResetStream(int64_t stream_id, uint64_t code) {
   // First, update the internal ngtcp2 state of the given stream
   // and schedule the STOP_SENDING and RESET_STREAM frames as
   // appropriate.

--- a/src/node_quic_session.h
+++ b/src/node_quic_session.h
@@ -651,7 +651,7 @@ class QuicSession : public AsyncWrap,
     return &streams_;
   }
 
-  // ShutdownStream will cause ngtcp2 to queue a
+  // ResetStream will cause ngtcp2 to queue a
   // RESET_STREAM and STOP_SENDING frame, as appropriate,
   // for the given stream_id. For a locally-initiated
   // unidirectional stream, only a RESET_STREAM frame
@@ -678,7 +678,7 @@ class QuicSession : public AsyncWrap,
   // Likewise, an idle timeout may cause the stream
   // to be silently destroyed without calling
   // ShutdownStream.
-  void ShutdownStream(
+  void ResetStream(
       int64_t stream_id,
       uint64_t error_code = NGTCP2_APP_NOERROR);
 

--- a/src/node_quic_stream.h
+++ b/src/node_quic_stream.h
@@ -324,7 +324,7 @@ class QuicStream : public AsyncWrap, public StreamBase {
   // Required for StreamBase
   int DoShutdown(ShutdownWrap* req_wrap) override;
 
-  void Shutdown(uint64_t app_error_code);
+  void ResetStream(uint64_t app_error_code);
 
   void Commit(ssize_t amount);
 


### PR DESCRIPTION
`Shutdown()` is already used in our own `StreamBase` API, and
in particular `QuicStream::Shutdown()` shadowed
`StreamBase::Shutdown()`; the former cleanly shuts down the
writable side of a stream, whereas the latter indicates an
abrupt termination through a `RESET_STREAM` frame.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
