### PR TITLE
[WIP] benchmark: add basic QUIC benchmark

### DIFF
--- a/benchmark/quic/quic-pipe.js
+++ b/benchmark/quic/quic-pipe.js
@@ -1,0 +1,73 @@
+// Test the speed of .pipe() with QUIC sockets
+'use strict';
+
+const common = require('../common.js');
+const quic = require('quic');
+const fixtures = require('../../test/common/fixtures');
+
+const key = fixtures.readKey('agent1-key.pem', 'binary');
+const cert = fixtures.readKey('agent1-cert.pem', 'binary');
+const ca = fixtures.readKey('ca1-cert.pem', 'binary');
+
+const bench = common.createBenchmark(main, {
+  dur: [5],
+});
+
+function main({ dur, len, type }) {
+  const server = quic.createSocket({ port: 0, validateAddress: true });
+
+  server.listen({
+    key,
+    cert,
+    ca,
+    rejectUnauthorized: false,
+    alpn: 'meow'
+  });
+
+  server.on('session', (session) => {
+    session.on('stream', (stream) => {
+      stream.pipe(stream);
+    });
+  });
+
+  const buffer = Buffer.alloc(102400);
+  let received = 0;
+
+  server.on('ready', () => {
+    const client = quic.createSocket({
+      port: 0,
+      client: {
+        key,
+        cert,
+        ca,
+        alpn: 'meow'
+      }
+    });
+
+    const req = client.connect({
+      address: 'localhost',
+      port: server.address.port
+    });
+
+    req.on('secure', () => {
+      const stream = req.openStream({ halfOpen: false });
+      stream.on('data', (chunk) => received += chunk.length);
+
+      function write() {
+        stream.write(buffer, write);
+      }
+
+      bench.start();
+      write();
+
+      setTimeout(() => {
+        // Multiply by 2 since we're sending it first one way
+        // then then back again.
+        const bytes = received * 2;
+        const gbits = (bytes * 8) / (1024 * 1024 * 1024);
+        bench.end(gbits);
+        process.exit(0);
+      }, dur * 1000);
+    });
+  });
+}


### PR DESCRIPTION
This is currently WIP, because it turns out that the retransmission timing is currently impractical for benchmarking (about 2/3 of the time are just spent waiting for the retransmission timer).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
