### PR TITLE
quic: make `maxConnectionsPerHost` works

### DIFF
--- a/src/node_quic_socket.h
+++ b/src/node_quic_socket.h
@@ -250,8 +250,8 @@ class QuicSocket : public AsyncWrap,
   // value reaches the value of max_connections_per_host_,
   // attempts to create new connections will be ignored
   // until the value falls back below the limit.
-  std::unordered_map<const sockaddr*, size_t, SocketAddress::Hash>
-      addr_counts_;
+  std::unordered_map<const sockaddr*, size_t, SocketAddress::Hash,
+      SocketAddress::Compare> addr_counts_;
 
   // The validated_addrs_ vector is used as an LRU cache for
   // validated addresses only when the VALIDATE_ADDRESS_LRU

--- a/src/node_quic_util.h
+++ b/src/node_quic_util.h
@@ -158,6 +158,14 @@ class SocketAddress {
     }
   };
 
+  // std::equal_to specialization for sockaddr instances (ipv4 or ipv6).
+  struct Compare {
+    bool operator()(const sockaddr* laddr, const sockaddr* raddr) const {
+      CHECK(laddr->sa_family == AF_INET || laddr->sa_family == AF_INET6);
+      return memcmp(laddr, raddr, GetAddressLen(laddr)) == 0;
+    }
+  };
+
   static bool numeric_host(const char* hostname) {
     return numeric_host(hostname, AF_INET) || numeric_host(hostname, AF_INET6);
   }

--- a/test/parallel/test-quic-maxconnectionsperhost.js
+++ b/test/parallel/test-quic-maxconnectionsperhost.js
@@ -1,0 +1,116 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasQuic)
+  common.skip('missing quic');
+
+const { createSocket } = require('quic');
+const fixtures = require('../common/fixtures');
+const key = fixtures.readKey('agent1-key.pem', 'binary');
+const cert = fixtures.readKey('agent1-cert.pem', 'binary');
+const ca = fixtures.readKey('ca1-cert.pem', 'binary');
+
+const kServerName = 'agent2';
+const kALPN = 'zzz';
+
+// QuicSockets must throw errors when maxConnectionsPerHost is not a
+// safe integer or is out of range.
+{
+  [-1, 0].forEach((maxConnectionsPerHost) => {
+    common.expectsError(() => createSocket({
+      port: 0,
+      maxConnectionsPerHost
+    }), {
+      type: RangeError,
+      code: 'ERR_OUT_OF_RANGE',
+      message: /The value of "options\.maxConnectionsPerHost" is out of range/
+    });
+  });
+
+  [Number.MAX_SAFE_INTEGER + 1, 1.1].forEach((maxConnectionsPerHost) => {
+    common.expectsError(() => createSocket({
+      port: 0,
+      maxConnectionsPerHost
+    }), {
+      type: TypeError,
+      code: 'ERR_INVALID_ARG_TYPE',
+      message: /The "options\.maxConnectionsPerHost" property must be of type safe integer\. Received type/
+    });
+  });
+}
+
+// Test that new client sessions will be closed when it exceeds
+// maxConnectionsPerHost.
+{
+  const kMaxConnectionsPerHost = 5;
+  const kIdleTimeout = 0;
+
+  let client;
+  let server;
+
+  function connect() {
+    return client.connect({
+      key,
+      cert,
+      ca,
+      address: common.localhostIPv4,
+      port: server.address.port,
+      servername: kServerName,
+      alpn: kALPN,
+      idleTimeout: kIdleTimeout,
+    });
+  }
+
+  server = createSocket({
+    port: 0,
+    maxConnectionsPerHost: kMaxConnectionsPerHost,
+  });
+
+  server.listen({
+    key,
+    cert,
+    ca,
+    alpn: kALPN,
+    idleTimeout: kIdleTimeout,
+  });
+
+  server.on('session', common.mustCall(() => {
+    // TODO(@oyyd): When maxConnectionsPerHost is exceeded, the new session
+    // will still be emitted and won't be destroied automatically. We need
+    // to figure out the reason and fix it.
+  }, kMaxConnectionsPerHost + 1));
+
+  server.on('ready', common.mustCall(async () => {
+    client = createSocket({
+      port: 0,
+    });
+
+    const sessions = [];
+
+    for (let i = 0; i < kMaxConnectionsPerHost; i += 1) {
+      const session = await new Promise((resolve) => {
+        const clientSession = connect();
+
+        clientSession.on('error', common.mustNotCall());
+        clientSession.on('secure', common.mustCall(() => {
+          resolve(clientSession);
+        }));
+      });
+
+      sessions.push(session);
+    }
+
+    // Sessions will be closed if the number of connceted sessions is equal
+    // to maxConnectionsPerHost.
+    await new Promise((resolve) => {
+      const clientSession = connect();
+      clientSession.on('error', common.mustNotCall());
+      clientSession.on('close', common.mustCall(() => {
+        resolve();
+      }));
+    });
+
+    client.close();
+    server.close();
+  }));
+}


### PR DESCRIPTION
It seems that `Hash` class for `unorderred_map` is used to decide which
bucket to put the key. But keys that are different pointers with the
same hash will still be regarded as different keys so that we still need
to specify a `std::equal_to` to compare the key correctly.

After this PR however, when `maxConnectionsPerHost` is exceeded, the new session will
still be emitted on the server side and won't be destroied automatically.
We need to figure out the reason and fix it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
