### PR TITLE
build: fail when quic is enabled with shared_openssl in configure

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1120,6 +1120,9 @@ def configure_node(o):
     o['variables']['debug_nghttp2'] = 'false'
 
   if options.experimental_quic:
+    if options.shared_openssl:
+      raise Exception('QUIC requires modified version of OpenSSL and cannot be'
+                      ' enabled with --shared_openssl.')
     o['variables']['experimental_quic'] = 1
   else:
     o['variables']['experimental_quic'] = 'false'

--- a/configure.py
+++ b/configure.py
@@ -1122,7 +1122,7 @@ def configure_node(o):
   if options.experimental_quic:
     if options.shared_openssl:
       raise Exception('QUIC requires modified version of OpenSSL and cannot be'
-                      ' enabled with --shared_openssl.')
+                      ' enabled with --shared-openssl.')
     o['variables']['experimental_quic'] = 1
   else:
     o['variables']['experimental_quic'] = 'false'


### PR DESCRIPTION
Fixes: https://github.com/nodejs/quic/issues/161

/cc @jasnell 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
