### PR TITLE
quic: additional sendretry tweaks + bug fix

### DIFF
--- a/src/node_quic_session.h
+++ b/src/node_quic_session.h
@@ -496,7 +496,8 @@ class QuicSession : public AsyncWrap,
   enum InitialPacketResult : int {
     PACKET_OK,
     PACKET_IGNORE,
-    PACKET_VERSION
+    PACKET_VERSION,
+    PACKET_RETRY
   };
 
   static InitialPacketResult Accept(

--- a/src/node_quic_socket.cc
+++ b/src/node_quic_socket.cc
@@ -567,7 +567,11 @@ BaseObjectPtr<QuicSession> QuicSocket::AcceptInitialPacket(
   switch (QuicSession::Accept(&hd, version, data, nread)) {
     case QuicSession::InitialPacketResult::PACKET_VERSION:
       SendVersionNegotiation(version, dcid, scid, addr);
-      // Fall through
+      return {};
+    case QuicSession::InitialPacketResult::PACKET_RETRY:
+      Debug(this, "0RTT Packet. Sending retry.");
+      SendRetry(version, dcid, scid, addr);
+      return {};
     case QuicSession::InitialPacketResult::PACKET_IGNORE:
       return {};
     case QuicSession::InitialPacketResult::PACKET_OK:

--- a/src/node_quic_socket.h
+++ b/src/node_quic_socket.h
@@ -119,6 +119,12 @@ class QuicSocket : public AsyncWrap,
   void OnSendDone(ReqWrap<uv_udp_send_t>* wrap, int status) override;
   void OnAfterBind() override;
 
+  bool SendRetry(
+      uint32_t version,
+      QuicCID* dcid,
+      QuicCID* scid,
+      const sockaddr* addr);
+
  private:
   static void OnAlloc(
       uv_handle_t* handle,
@@ -167,11 +173,6 @@ class QuicSocket : public AsyncWrap,
       const uint8_t* data,
       const struct sockaddr* addr,
       unsigned int flags);
-  bool SendRetry(
-      uint32_t version,
-      QuicCID* dcid,
-      QuicCID* scid,
-      const sockaddr* addr);
 
   void IncrementSocketAddressCounter(const sockaddr* addr);
   void DecrementSocketAddressCounter(const sockaddr* addr);

--- a/src/node_quic_socket.h
+++ b/src/node_quic_socket.h
@@ -67,13 +67,13 @@ class QuicSocket : public AsyncWrap,
   void MaybeClose();
 
   void AddSession(
-      QuicCID* cid,
+      const QuicCID& cid,
       BaseObjectPtr<QuicSession> session);
   void AssociateCID(
-      QuicCID* cid,
-      QuicCID* scid);
+      const QuicCID& cid,
+      const QuicCID& scid);
   void DisassociateCID(
-      QuicCID* cid);
+      const QuicCID& cid);
   void Listen(
       crypto::SecureContext* context,
       const sockaddr* preferred_address = nullptr,
@@ -82,7 +82,7 @@ class QuicSocket : public AsyncWrap,
   int ReceiveStart();
   int ReceiveStop();
   void RemoveSession(
-      QuicCID* cid,
+      const QuicCID& cid,
       const sockaddr* addr);
   void ReportSendError(
       int error);
@@ -121,8 +121,8 @@ class QuicSocket : public AsyncWrap,
 
   bool SendRetry(
       uint32_t version,
-      QuicCID* dcid,
-      QuicCID* scid,
+      const QuicCID& dcid,
+      const QuicCID& scid,
       const sockaddr* addr);
 
  private:
@@ -147,13 +147,13 @@ class QuicSocket : public AsyncWrap,
   void SendInitialConnectionClose(
       uint32_t version,
       uint64_t error_code,
-      QuicCID* dcid,
+      const QuicCID& dcid,
       const sockaddr* addr);
 
   void SendVersionNegotiation(
       uint32_t version,
-      QuicCID* dcid,
-      QuicCID* scid,
+      const QuicCID& dcid,
+      const QuicCID& scid,
       const sockaddr* addr);
 
   void OnSend(
@@ -167,8 +167,8 @@ class QuicSocket : public AsyncWrap,
 
   BaseObjectPtr<QuicSession> AcceptInitialPacket(
       uint32_t version,
-      QuicCID* dcid,
-      QuicCID* scid,
+      const QuicCID& dcid,
+      const QuicCID& scid,
       ssize_t nread,
       const uint8_t* data,
       const struct sockaddr* addr,

--- a/src/node_quic_util.h
+++ b/src/node_quic_util.h
@@ -353,7 +353,7 @@ class QuicCID {
 
   const ngtcp2_cid* operator*() const { return &cid_; }
 
-  uint8_t* data() { return cid_.data; }
+  const uint8_t* data() const { return cid_.data; }
   size_t length() const { return cid_.datalen; }
 
  private:


### PR DESCRIPTION
Additional send-retry handling + a bug fix from the qlog PR

@addaleax ... there was a minor issue from the qlog PR where the ~QuicSession would assert due to lack of a `HandleScope`.

