### PR TITLE
 quic: do not send data for QuicSessions without QuicSockets

### DIFF
--- a/src/node_quic_session.cc
+++ b/src/node_quic_session.cc
@@ -2356,10 +2356,12 @@ void QuicSession::SendPendingData() {
   //  * The QuicSession has been destroyed
   //  * The QuicSession is in the draining period
   //  * The QuicSession is a server in the closing period
+  //  * The QuicSession is not currently associated with a QuicSocket
   if (Ngtcp2CallbackScope::InNgtcp2CallbackScope(this) ||
       IsFlagSet(QUICSESSION_FLAG_DESTROYED) ||
       IsInDrainingPeriod() ||
-      (IsServer() && IsInClosingPeriod())) {
+      (IsServer() && IsInClosingPeriod()) ||
+      Socket() == nullptr) {
     return;
   }
 

--- a/src/node_quic_session.cc
+++ b/src/node_quic_session.cc
@@ -2135,7 +2135,7 @@ void QuicSession::RemoveFromSocket() {
   std::vector<ngtcp2_cid> cids(ngtcp2_conn_get_num_scid(Connection()));
   ngtcp2_conn_get_scid(Connection(), cids.data());
 
-  for (auto &cid : cids)
+  for (const ngtcp2_cid& cid : cids)
     socket_->DisassociateCID(QuicCID(&cid));
 
   Debug(this, "Removed from the QuicSocket.");

--- a/src/node_quic_socket.cc
+++ b/src/node_quic_socket.cc
@@ -414,7 +414,7 @@ void QuicSocket::OnEndpointDone(QuicEndpoint* endpoint) {
 }
 
 void QuicSocket::OnBind(QuicEndpoint* endpoint) {
-  auto& local_address = endpoint->GetLocalAddress();
+  const SocketAddress& local_address = endpoint->GetLocalAddress();
   Debug(this, "Endpoint %s:%d bound",
         local_address.GetAddress().c_str(),
         local_address.GetPort());

--- a/src/node_quic_util-inl.h
+++ b/src/node_quic_util-inl.h
@@ -203,10 +203,10 @@ const sockaddr_in* QuicPreferredAddress::PreferredIPv4Address() const {
   return reinterpret_cast<const sockaddr_in*>(&paddr_->ipv4_addr);
 }
 
-const int16_t QuicPreferredAddress::PreferredIPv6Port() const {
+int16_t QuicPreferredAddress::PreferredIPv6Port() const {
   return paddr_->ipv6_port;
 }
-const int16_t QuicPreferredAddress::PreferredIPv4Port() const {
+int16_t QuicPreferredAddress::PreferredIPv4Port() const {
   return paddr_->ipv4_port;
 }
 
@@ -221,6 +221,7 @@ bool QuicPreferredAddress::Use(int family) const {
   dest_->addrlen = req.addrinfo->ai_addrlen;
   memcpy(dest_->addr, req.addrinfo->ai_addr, req.addrinfo->ai_addrlen);
   uv_freeaddrinfo(req.addrinfo);
+  return true;
 }
 
 bool QuicPreferredAddress::IsEmptyAddress(

--- a/src/node_quic_util.h
+++ b/src/node_quic_util.h
@@ -90,8 +90,8 @@ class QuicPreferredAddress {
   inline const ngtcp2_cid* cid() const;
   inline const sockaddr_in6* PreferredIPv6Address() const;
   inline const sockaddr_in* PreferredIPv4Address() const;
-  inline const int16_t PreferredIPv6Port() const;
-  inline const int16_t PreferredIPv4Port() const;
+  inline int16_t PreferredIPv6Port() const;
+  inline int16_t PreferredIPv4Port() const;
   inline const uint8_t* StatelessResetToken() const;
 
   inline bool Use(int family = AF_INET) const;


### PR DESCRIPTION
#### quic: minor cleanups

Code clarity and silencing compiler warnings.

#### quic: do not send data for QuicSessions without QuicSockets

This fixes a crash in `parallel/test-quic-process-cleanup`.



<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
