### PR TITLE
fix(quic): fix idle timeout unit

### DIFF
--- a/lib/internal/quic/util.js
+++ b/lib/internal/quic/util.js
@@ -542,7 +542,7 @@ function setTransportParams(config) {
                                maxStreamsUni,
                                IDX_QUIC_SESSION_MAX_STREAMS_UNI) |
                 setConfigField(sessionConfig,
-                               idleTimeout * 1000000,  // millis to nano
+                               idleTimeout,
                                IDX_QUIC_SESSION_IDLE_TIMEOUT) |
                 setConfigField(sessionConfig,
                                maxAckDelay,

--- a/src/quic/node_quic_session.cc
+++ b/src/quic/node_quic_session.cc
@@ -2634,7 +2634,8 @@ void QuicSession::UpdateIdleTimer() {
   CHECK_NOT_NULL(idle_);
   uint64_t now = uv_hrtime();
   uint64_t expiry = ngtcp2_conn_get_idle_expiry(Connection());
-  uint64_t timeout = expiry > now ? (expiry - now) / 1000 : 1;
+  // nano to millis
+  uint64_t timeout = expiry > now ? (expiry - now) / 1e6 : 1;
   if (timeout == 0) timeout = 1;
   Debug(this, "Updating idle timeout to %" PRIu64, timeout);
   idle_->Update(timeout);


### PR DESCRIPTION
The idle_timeout is regarded as milliseconds: https://tools.ietf.org/html/draft-ietf-quic-transport-24#section-18.2

ngtcp2: https://github.com/ngtcp2/ngtcp2/blob/0a29f83a9d2b9435b5b3480c5c14fa505a4026c7/lib/ngtcp2_crypto.c#L448

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
