### PR TITLE
quic: attach keylog and pathvalidation handlers on client init

### DIFF
--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -672,11 +672,11 @@ function createSecureContext(options, init_cb) {
 }
 
 function onNewListener(event) {
-  toggleListeners(this, event, 1);
+  toggleListeners(this[kHandle], event, true);
 }
 
 function onRemoveListener(event) {
-  toggleListeners(this, event, 0);
+  toggleListeners(this[kHandle], event, false);
 }
 
 // QuicEndpoint wraps a UDP socket.
@@ -1501,6 +1501,7 @@ class QuicSession extends EventEmitter {
   [kSetHandle](handle) {
     this[kHandle] = handle;
     if (handle !== undefined) {
+      handle[owner_symbol] = this;
       this.#handshakeAckHistogram =
         new Histogram(handle.crypto_rx_ack);
       this.#handshakeContinuationHistogram =
@@ -2004,7 +2005,6 @@ class QuicServerSession extends QuicSession {
   constructor(socket, handle) {
     super(socket);
     this[kSetHandle](handle);
-    handle[owner_symbol] = this;
   }
 
   [kClientHello](alpn, servername, ciphers, callback) {
@@ -2188,6 +2188,7 @@ class QuicClientSession extends QuicSession {
         this.alpnProtocol,
         options,
         this.#qlogEnabled);
+
     // We no longer need these, unset them so
     // memory can be garbage collected.
     this.#remoteTransportParams = undefined;
@@ -2208,12 +2209,19 @@ class QuicClientSession extends QuicSession {
       this.destroy(new ERR_QUICCLIENTSESSION_FAILED(reason));
       return;
     }
+
     this[kInit](handle);
   }
 
   [kInit](handle) {
     this[kSetHandle](handle);
-    handle[owner_symbol] = this;
+
+    if (this.listenerCount('keylog') > 0)
+      toggleListeners(handle, 'keylog', true);
+
+    if (this.listenerCount('pathValidation') > 0)
+      toggleListeners(handle, 'pathValidation', true);
+
     this.#handleReady = true;
     this[kMaybeReady]();
   }

--- a/lib/internal/quic/util.js
+++ b/lib/internal/quic/util.js
@@ -580,21 +580,22 @@ function setTransportParams(config) {
 // communicate that a handler has been added for the optional events
 // so that the C++ internals know there is an actual listener. The event
 // will not be emitted if there is no handler.
-function toggleListeners(self, event, on = 1) {
-  if (self[kHandle] === undefined || self.listenerCount(event) !== 0)
+function toggleListeners(handle, event, on) {
+  if (handle === undefined)
     return;
+  const val = on ? 1 : 0;
   switch (event) {
     case 'keylog':
-      self[kHandle].state[IDX_QUIC_SESSION_STATE_KEYLOG_ENABLED] = on;
+      handle.state[IDX_QUIC_SESSION_STATE_KEYLOG_ENABLED] = val;
       break;
     case 'clientHello':
-      self[kHandle].state[IDX_QUIC_SESSION_STATE_CLIENT_HELLO_ENABLED] = on;
+      handle.state[IDX_QUIC_SESSION_STATE_CLIENT_HELLO_ENABLED] = val;
       break;
     case 'pathValidation':
-      self[kHandle].state[IDX_QUIC_SESSION_STATE_PATH_VALIDATED_ENABLED] = on;
+      handle.state[IDX_QUIC_SESSION_STATE_PATH_VALIDATED_ENABLED] = val;
       break;
     case 'OCSPRequest':
-      self[kHandle].state[IDX_QUIC_SESSION_STATE_CERT_ENABLED] = on;
+      handle.state[IDX_QUIC_SESSION_STATE_CERT_ENABLED] = val;
       break;
   }
 }

--- a/test/parallel/test-quic-keylog.js
+++ b/test/parallel/test-quic-keylog.js
@@ -55,15 +55,9 @@ server.on('ready', common.mustCall(() => {
 
   const kClientKeylogs = Array.from(kKeylogs);
 
-  // TODO(@jasnell): There's currently a bug that prevents
-  // the keylog event handler from being registered until
-  // the underlying handle is available... so we need to
-  // wait to attach on the ready event.
-  req.on('ready', common.mustCall(() => {
-    req.on('keylog', common.mustCall((line) => {
-      assert(kClientKeylogs.shift().test(line));
-    }, kClientKeylogs.length));
-  }));
+  req.on('keylog', common.mustCall((line) => {
+    assert(kClientKeylogs.shift().test(line));
+  }, kClientKeylogs.length));
 
   req.on('secure', common.mustCall((servername, alpn, cipher) => {
     const stream = req.openStream();


### PR DESCRIPTION
Enable the keylog and pathValidation event handlers when the
client session handle is created.

Fixes: https://github.com/nodejs/quic/issues/249

