### PR TITLE
quic: refactor use preferred address strategy

### DIFF
--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -847,6 +847,23 @@ three arguments:
 The `sessionTicket` and `remoteTransportParams` are useful when creating a new
 `QuicClientSession` to more quickly resume an existing session.
 
+#### Event: `'usePreferredAddress'`
+<!-- YAML
+added: REPLACEME
+-->
+
+The `'usePreferredAddress'` event is emitted when the client `QuicSession`
+is updated to use the server-advertised preferred address. The callback is
+invoked with a single `address` argument:
+
+* `address` {Object}
+  * `address` {string} The preferred hostname
+  * `port` {number} The preferred IP port
+  * `type` {string} Either `'udp4'` or `'udp6'`.
+
+This event is purely informational and will be emitted only when
+`preferredAddressPolicy` is set to `'accept'`.
+
 #### quicclientsession.ephemeralKeyInfo
 <!-- YAML
 added: REPLACEME
@@ -1172,7 +1189,9 @@ added: REPLACEME
     decrypted with `object.passphrase` if provided, or `options.passphrase` if
     it is not.
   * `port` {number} The IP port of the remote QUIC server.
-  * `preferredAddressPolicy` {string} `'accept'` or `'reject'`.
+  * `preferredAddressPolicy` {string} `'accept'` or `'reject'`. When `'accept'`,
+    indicates that the client will automatically use the preferred address
+    advertised by the server.
   * `remoteTransportParams` {Buffer|TypedArray|DataView} The serialized remote
     transport parameters from a previously established session. These would
     have been provided as part of the `'sessionTicket'` event on a previous

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -212,6 +212,7 @@ const kStreamClose = Symbol('kStreamClose');
 const kStreamReset = Symbol('kStreamReset');
 const kTrackWriteState = Symbol('kTrackWriteState');
 const kUDPHandleForTesting = Symbol('kUDPHandleForTesting');
+const kUsePreferredAddress = Symbol('kUsePreferredAddress');
 const kVersionNegotiation = Symbol('kVersionNegotiation');
 const kWriteGeneric = Symbol('kWriteGeneric');
 
@@ -401,6 +402,15 @@ function onSessionPathValidation(res, local, remote) {
   }
 }
 
+function onSessionUsePreferredAddress(address, port, family) {
+  const session = this[owner_symbol];
+  session[kUsePreferredAddress]({
+    address,
+    port,
+    type: family === AF_INET6 ? 'udp6' : 'udp4'
+  });
+}
+
 // Called by the C++ internals to emit a QLog record.
 function onSessionQlog(str) {
   if (this.qlogBuffer === undefined) this.qlogBuffer = '';
@@ -538,6 +548,7 @@ setCallbacks({
   onStreamError,
   onStreamReset,
   onSessionPathValidation,
+  onSessionUsePreferredAddress,
   onStreamHeaders,
 });
 
@@ -1655,6 +1666,11 @@ class QuicSession extends EventEmitter {
       this.destroy();
   }
 
+  [kUsePreferredAddress](address) {
+    process.nextTick(
+      emit.bind(this, 'usePreferredAddress', address));
+  }
+
   // Closing allows any existing QuicStream's to complete
   // normally but disallows any new QuicStreams from being
   // opened. Calls to openStream() will fail, and new streams
@@ -2221,6 +2237,9 @@ class QuicClientSession extends QuicSession {
 
     if (this.listenerCount('pathValidation') > 0)
       toggleListeners(handle, 'pathValidation', true);
+
+    if (this.listenerCount('usePreferredAddress') > 0)
+      toggleListeners(handle, 'usePreferredAddress', true);
 
     this.#handleReady = true;
     this[kMaybeReady]();

--- a/lib/internal/quic/util.js
+++ b/lib/internal/quic/util.js
@@ -46,6 +46,7 @@ const {
     IDX_QUIC_SESSION_STATE_CLIENT_HELLO_ENABLED,
     IDX_QUIC_SESSION_STATE_KEYLOG_ENABLED,
     IDX_QUIC_SESSION_STATE_PATH_VALIDATED_ENABLED,
+    IDX_QUIC_SESSION_STATE_USE_PREFERRED_ADDRESS_ENABLED,
     IDX_HTTP3_QPACK_MAX_TABLE_CAPACITY,
     IDX_HTTP3_QPACK_BLOCKED_STREAMS,
     IDX_HTTP3_MAX_HEADER_LIST_SIZE,
@@ -596,6 +597,9 @@ function toggleListeners(handle, event, on) {
       break;
     case 'OCSPRequest':
       handle.state[IDX_QUIC_SESSION_STATE_CERT_ENABLED] = val;
+      break;
+    case 'usePreferredAddress':
+      handle.state[IDX_QUIC_SESSION_STATE_USE_PREFERRED_ADDRESS_ENABLED] = on;
       break;
   }
 }

--- a/src/env.h
+++ b/src/env.h
@@ -445,6 +445,7 @@ constexpr size_t kFsStatsBufferLength =
   V(quic_on_session_handshake_function, v8::Function)                          \
   V(quic_on_session_keylog_function, v8::Function)                             \
   V(quic_on_session_path_validation_function, v8::Function)                    \
+  V(quic_on_session_use_preferred_address_function, v8::Function)              \
   V(quic_on_session_qlog_function, v8::Function)                               \
   V(quic_on_session_ready_function, v8::Function)                              \
   V(quic_on_session_silent_close_function, v8::Function)                       \

--- a/src/quic/node_quic.cc
+++ b/src/quic/node_quic.cc
@@ -59,6 +59,7 @@ void QuicSetCallbacks(const FunctionCallbackInfo<Value>& args) {
   SETFUNCTION("onSessionError", session_error);
   SETFUNCTION("onSessionHandshake", session_handshake);
   SETFUNCTION("onSessionKeylog", session_keylog);
+  SETFUNCTION("onSessionUsePreferredAddress", session_use_preferred_address);
   SETFUNCTION("onSessionPathValidation", session_path_validation);
   SETFUNCTION("onSessionQlog", session_qlog);
   SETFUNCTION("onSessionSilentClose", session_silent_close);
@@ -144,6 +145,8 @@ void Initialize(Local<Object> target,
   NODE_DEFINE_CONSTANT(constants, DEFAULT_MAX_CONNECTIONS_PER_HOST);
   NODE_DEFINE_CONSTANT(constants, IDX_QUIC_SESSION_STATE_CERT_ENABLED);
   NODE_DEFINE_CONSTANT(constants, IDX_QUIC_SESSION_STATE_CLIENT_HELLO_ENABLED);
+  NODE_DEFINE_CONSTANT(constants,
+                       IDX_QUIC_SESSION_STATE_USE_PREFERRED_ADDRESS_ENABLED);
   NODE_DEFINE_CONSTANT(constants,
                        IDX_QUIC_SESSION_STATE_PATH_VALIDATED_ENABLED);
   NODE_DEFINE_CONSTANT(constants, IDX_QUIC_SESSION_STATE_KEYLOG_ENABLED);

--- a/src/quic/node_quic_session-inl.h
+++ b/src/quic/node_quic_session-inl.h
@@ -78,6 +78,27 @@ void QuicSession::StartGracefulClose() {
   session_stats_.closing_at = uv_hrtime();
 }
 
+// The connection ID Strategy is a function that generates
+// connection ID values. By default these are generated randomly.
+void QuicSession::SetConnectionIDStrategy(ConnectionIDStrategy strategy) {
+  CHECK_NOT_NULL(strategy);
+  connection_id_strategy_ = strategy;
+}
+
+// The stateless reset token strategy is a function that generates
+// stateless reset tokens. By default these are cryptographically
+// derived by the CID.
+void QuicSession::SetStatelessResetTokenStrategy(
+    StatelessResetTokenStrategy strategy) {
+  CHECK_NOT_NULL(strategy);
+  stateless_reset_strategy_ = strategy;
+}
+
+void QuicSession::SetPreferredAddressStrategy(
+    PreferredAddressStrategy strategy) {
+  preferred_address_strategy_ = strategy;
+}
+
 QuicSocket* QuicSession::Socket() const {
   return socket_.get();
 }

--- a/src/quic/node_quic_util.h
+++ b/src/quic/node_quic_util.h
@@ -88,8 +88,8 @@ class QuicPreferredAddress {
       paddr_(paddr) {}
 
   inline const ngtcp2_cid* cid() const;
-  inline const sockaddr_in6* PreferredIPv6Address() const;
-  inline const sockaddr_in* PreferredIPv4Address() const;
+  inline std::string PreferredIPv6Address() const;
+  inline std::string PreferredIPv4Address() const;
   inline int16_t PreferredIPv6Port() const;
   inline int16_t PreferredIPv4Port() const;
   inline const uint8_t* StatelessResetToken() const;
@@ -100,10 +100,6 @@ class QuicPreferredAddress {
   inline bool ResolvePreferredAddress(
       int local_address_family,
       uv_getaddrinfo_t* req) const;
-
-  inline bool IsEmptyAddress(
-      const uint8_t* addr,
-      size_t len) const;
 
   Environment* env_;
   mutable ngtcp2_addr* dest_;

--- a/test/parallel/test-quic-client-server.js
+++ b/test/parallel/test-quic-client-server.js
@@ -76,6 +76,8 @@ server.on('session', common.mustCall((session) => {
     debug(`QuicServerSession Client ${family} address ${address}:${port}`);
   }
 
+  session.on('usePreferredAddress', common.mustNotCall());
+
   session.on('clientHello', common.mustCall(
     (alpn, servername, ciphers, cb) => {
       assert.strictEqual(alpn, kALPN);
@@ -225,6 +227,8 @@ server.on('ready', common.mustCall(() => {
   });
 
   assert.strictEqual(req.servername, kServerName);
+
+  req.on('usePreferredAddress', common.mustNotCall());
 
   req.on('OCSPResponse', common.mustCall((response) => {
     debug(`QuicClientSession OCSP response: "${response.toString()}"`);

--- a/test/sequential/test-quic-preferred-address-ipv6.js
+++ b/test/sequential/test-quic-preferred-address-ipv6.js
@@ -1,0 +1,99 @@
+// Flags: --expose-internals --no-warnings
+'use strict';
+
+const common = require('../common');
+if (!common.hasQuic)
+  common.skip('missing quic');
+
+const { Buffer } = require('buffer');
+const Countdown = require('../common/countdown');
+const assert = require('assert');
+const fixtures = require('../common/fixtures');
+const key = fixtures.readKey('agent1-key.pem', 'binary');
+const cert = fixtures.readKey('agent1-cert.pem', 'binary');
+const ca = fixtures.readKey('ca1-cert.pem', 'binary');
+const { debuglog } = require('util');
+const debug = debuglog('test');
+
+const { createSocket } = require('quic');
+
+let client;
+
+const server = createSocket({ endpoint: { type: 'udp6' } });
+const endpoint2 = server.addEndpoint({
+  type: 'udp6',
+  port: common.PORT
+});
+
+const kALPN = 'zzz';  // ALPN can be overriden to whatever we want
+
+const countdown = new Countdown(1, () => {
+  debug('Countdown expired. Destroying sockets');
+  server.close();
+  client.close();
+});
+
+server.listen({ key, cert, ca, alpn: kALPN, preferredAddress: {
+  port: common.PORT,
+  address: '::',
+  type: 'udp6',
+} });
+
+server.on('session', common.mustCall((session) => {
+  debug('QuicServerSession Created');
+  session.on('stream', common.mustCall((stream) => {
+    stream.end('hello world');
+    stream.resume();
+    stream.on('close', common.mustCall());
+    stream.on('finish', common.mustCall());
+  }));
+}));
+
+server.on('ready', common.mustCall(() => {
+  const endpoints = server.endpoints;
+  for (const endpoint of endpoints) {
+    const address = endpoint.address;
+    debug('Server is listening on address %s:%d',
+          address.address,
+          address.port);
+  }
+  const endpoint = endpoints[0];
+
+  client = createSocket({ endpoint: { type: 'udp6' }, client: {
+    key,
+    cert,
+    ca,
+    alpn: kALPN,
+    preferredAddressPolicy: 'accept' } });
+
+  client.on('close', common.mustCall());
+
+  const req = client.connect({
+    address: 'localhost',
+    port: endpoint.address.port,
+    servername: 'localhost',
+    type: 'udp6',
+  });
+
+  req.on('ready', common.mustCall(() => {
+    req.on('usePreferredAddress', common.mustCall(({address, port, type}) => {
+      assert.strictEqual(address, '::');
+      assert.strictEqual(port, common.PORT);
+      assert.strictEqual(type, 'udp6');
+    }));
+  }));
+
+  req.on('secure', common.mustCall((servername, alpn, cipher) => {
+    const stream = req.openStream();
+    stream.end('hello world');
+    stream.resume();
+
+    stream.on('close', common.mustCall(() => {
+      countdown.dec();
+    }));
+  }));
+
+  req.on('close', common.mustCall());
+}));
+
+server.on('listening', common.mustCall());

--- a/test/sequential/test-quic-preferred-address.js
+++ b/test/sequential/test-quic-preferred-address.js
@@ -1,0 +1,95 @@
+// Flags: --expose-internals --no-warnings
+'use strict';
+
+const common = require('../common');
+if (!common.hasQuic)
+  common.skip('missing quic');
+
+const { Buffer } = require('buffer');
+const Countdown = require('../common/countdown');
+const assert = require('assert');
+const fixtures = require('../common/fixtures');
+const key = fixtures.readKey('agent1-key.pem', 'binary');
+const cert = fixtures.readKey('agent1-cert.pem', 'binary');
+const ca = fixtures.readKey('ca1-cert.pem', 'binary');
+const { debuglog } = require('util');
+const debug = debuglog('test');
+
+const { createSocket } = require('quic');
+
+let client;
+
+const server = createSocket();
+const endpoint2 = server.addEndpoint({ port: common.PORT });
+
+const kALPN = 'zzz';  // ALPN can be overriden to whatever we want
+
+const countdown = new Countdown(1, () => {
+  debug('Countdown expired. Destroying sockets');
+  server.close();
+  client.close();
+});
+
+server.listen({ key, cert, ca, alpn: kALPN, preferredAddress: {
+  port: common.PORT,
+  address: '0.0.0.0',
+  type: 'udp4',
+} });
+
+server.on('session', common.mustCall((session) => {
+  debug('QuicServerSession Created');
+  session.on('stream', common.mustCall((stream) => {
+    stream.end('hello world');
+    stream.resume();
+    stream.on('close', common.mustCall());
+    stream.on('finish', common.mustCall());
+  }));
+}));
+
+server.on('ready', common.mustCall(() => {
+  const endpoints = server.endpoints;
+  for (const endpoint of endpoints) {
+    const address = endpoint.address;
+    debug('Server is listening on address %s:%d',
+          address.address,
+          address.port);
+  }
+  const endpoint = endpoints[0];
+
+  client = createSocket({ client: {
+    key,
+    cert,
+    ca,
+    alpn: kALPN,
+    preferredAddressPolicy: 'accept' } });
+
+  client.on('close', common.mustCall());
+
+  const req = client.connect({
+    address: 'localhost',
+    port: endpoint.address.port,
+    servername: 'localhost',
+  });
+
+  req.on('ready', common.mustCall(() => {
+    req.on('usePreferredAddress', common.mustCall(({address, port, type}) => {
+      assert.strictEqual(address, '0.0.0.0');
+      assert.strictEqual(port, common.PORT);
+      assert.strictEqual(type, 'udp4');
+    }));
+  }));
+
+  req.on('secure', common.mustCall((servername, alpn, cipher) => {
+    const stream = req.openStream();
+    stream.end('hello world');
+    stream.resume();
+
+    stream.on('close', common.mustCall(() => {
+      countdown.dec();
+    }));
+  }));
+
+  req.on('close', common.mustCall());
+}));
+
+server.on('listening', common.mustCall());


### PR DESCRIPTION
Refactor preferred address strategy internals + add usePreferredAddress
event on the JavaScript so user code can know when the remote address
has been modified.
