### PR TITLE
quic: fixing stateless reset

### DIFF
--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -259,6 +259,9 @@ added: REPLACEME
   * `lookup` {Function} A custom DNS lookup function. Default `dns.lookup()`.
   * `maxConnectionsPerHost` {number} The maximum number of inbound connections
     allowed per remote host. Default: `100`.
+  * `maxStatelessResetsPerHost` {number} The maximum number of stateless
+    resets that the `QuicSocket` is permitted to send per remote host.
+    Default: `10`.
   * `qlog` {boolean} Whether to emit ['qlog'][] events for incoming sessions.
     (For outgoing client sessions, set `client.qlog`.) Default: `false`.
   * `retryTokenTimeout` {number} The maximum number of *seconds* for retry token

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -921,6 +921,9 @@ class QuicSocket extends EventEmitter {
       // The maximum number of connections per host
       maxConnectionsPerHost,
 
+      // The maximum number of stateless resets per host
+      maxStatelessResetsPerHost,
+
       // The maximum number of seconds for retry token
       retryTokenTimeout,
 
@@ -962,6 +965,7 @@ class QuicSocket extends EventEmitter {
         socketOptions,
         retryTokenTimeout,
         maxConnectionsPerHost,
+        maxStatelessResetsPerHost,
         qlog,
         statelessResetSecret,
         disableStatelessReset));

--- a/lib/internal/quic/util.js
+++ b/lib/internal/quic/util.js
@@ -29,6 +29,7 @@ const {
     AF_INET6,
     DEFAULT_RETRYTOKEN_EXPIRATION,
     DEFAULT_MAX_CONNECTIONS_PER_HOST,
+    DEFAULT_MAX_STATELESS_RESETS_PER_HOST,
     IDX_QUIC_SESSION_ACTIVE_CONNECTION_ID_LIMIT,
     IDX_QUIC_SESSION_MAX_STREAM_DATA_BIDI_LOCAL,
     IDX_QUIC_SESSION_MAX_STREAM_DATA_BIDI_REMOTE,
@@ -429,6 +430,7 @@ function validateQuicSocketOptions(options = {}) {
     endpoint = { port: 0, type: 'udp4' },
     lookup,
     maxConnectionsPerHost = DEFAULT_MAX_CONNECTIONS_PER_HOST,
+    maxStatelessResetsPerHost = DEFAULT_MAX_STATELESS_RESETS_PER_HOST,
     qlog = false,
     retryTokenTimeout = DEFAULT_RETRYTOKEN_EXPIRATION,
     server,
@@ -458,6 +460,10 @@ function validateQuicSocketOptions(options = {}) {
     maxConnectionsPerHost,
     'options.maxConnectionsPerHost',
     1, Number.MAX_SAFE_INTEGER);
+  validateNumberInBoundedRange(
+    maxStatelessResetsPerHost,
+    'options.maxStatelessResetsPerHost',
+    1, Number.MAX_SAFE_INTEGER);
 
   if (statelessResetSecret) {
     if (!isArrayBufferView(statelessResetSecret)) {
@@ -476,6 +482,7 @@ function validateQuicSocketOptions(options = {}) {
     client,
     lookup,
     maxConnectionsPerHost,
+    maxStatelessResetsPerHost,
     retryTokenTimeout,
     server,
     type: getSocketType(type),

--- a/node.gyp
+++ b/node.gyp
@@ -852,6 +852,7 @@
             'src/quic/node_quic_session.h',
             'src/quic/node_quic_session-inl.h',
             'src/quic/node_quic_socket.h',
+            'src/quic/node_quic_socket-inl.h',
             'src/quic/node_quic_stream.h',
             'src/quic/node_quic_stream-inl.h',
             'src/quic/node_quic_util.h',

--- a/src/node_sockaddr-inl.h
+++ b/src/node_sockaddr-inl.h
@@ -24,8 +24,7 @@ inline void hash_combine(size_t* seed, const T& value, Args... rest) {
 }
 
 size_t SocketAddress::Hash::operator()(const SocketAddress& addr) const {
-  Hash hash;
-  return hash(addr.data());
+  return Hash()(addr.data());
 }
 
 size_t SocketAddress::Hash::operator()(const sockaddr* addr) const {
@@ -54,8 +53,7 @@ size_t SocketAddress::Hash::operator()(const sockaddr* addr) const {
 bool SocketAddress::Compare::operator()(
     const SocketAddress& laddr,
     const SocketAddress& raddr) const {
-  Compare compare;
-  return compare(laddr.data(), raddr.data());
+  return Compare()(laddr.data(), raddr.data());
 }
 
 bool SocketAddress::Compare::operator()(

--- a/src/node_sockaddr.h
+++ b/src/node_sockaddr.h
@@ -4,15 +4,17 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "env.h"
+#include "memory_tracker.h"
 #include "node.h"
 #include "uv.h"
 #include "v8.h"
 
 #include <string>
+#include <unordered_map>
 
 namespace node {
 
-class SocketAddress {
+class SocketAddress : public MemoryRetainer {
  public:
   struct Hash {
     inline size_t operator()(const sockaddr* addr) const;
@@ -116,6 +118,10 @@ class SocketAddress {
       Environment* env,
       v8::Local<v8::Object> obj = v8::Local<v8::Object>()) const;
 
+  SET_NO_MEMORY_INFO()
+  SET_MEMORY_INFO_NAME(SocketAddress)
+  SET_SELF_SIZE(SocketAddress)
+
  private:
   template <typename T, typename F>
   static SocketAddress* FromUVHandle(
@@ -131,6 +137,13 @@ class SocketAddress {
 
   sockaddr_storage address_;
 };
+
+template <typename T>
+using SocketAddressMap =
+    std::unordered_map<
+        SocketAddress, T,
+        SocketAddress::Hash,
+        SocketAddress::Compare>;
 
 }  // namespace node
 

--- a/src/quic/node_quic.cc
+++ b/src/quic/node_quic.cc
@@ -8,7 +8,7 @@
 #include "node_process.h"
 #include "node_quic_crypto.h"
 #include "node_quic_session-inl.h"
-#include "node_quic_socket.h"
+#include "node_quic_socket-inl.h"
 #include "node_quic_stream-inl.h"
 #include "node_quic_state.h"
 #include "node_quic_util-inl.h"
@@ -143,6 +143,7 @@ void Initialize(Local<Object> target,
   NODE_DEFINE_CONSTANT(constants, DEFAULT_MAX_STREAM_DATA_BIDI_LOCAL);
   NODE_DEFINE_CONSTANT(constants, DEFAULT_RETRYTOKEN_EXPIRATION);
   NODE_DEFINE_CONSTANT(constants, DEFAULT_MAX_CONNECTIONS_PER_HOST);
+  NODE_DEFINE_CONSTANT(constants, DEFAULT_MAX_STATELESS_RESETS_PER_HOST);
   NODE_DEFINE_CONSTANT(constants, IDX_QUIC_SESSION_STATE_CERT_ENABLED);
   NODE_DEFINE_CONSTANT(constants, IDX_QUIC_SESSION_STATE_CLIENT_HELLO_ENABLED);
   NODE_DEFINE_CONSTANT(constants,

--- a/src/quic/node_quic_default_application.cc
+++ b/src/quic/node_quic_default_application.cc
@@ -2,7 +2,7 @@
 #include "node_quic_buffer-inl.h"
 #include "node_quic_default_application.h"
 #include "node_quic_session-inl.h"
-#include "node_quic_socket.h"
+#include "node_quic_socket-inl.h"
 #include "node_quic_stream-inl.h"
 #include "node_quic_util-inl.h"
 #include "node_sockaddr-inl.h"

--- a/src/quic/node_quic_http3_application.cc
+++ b/src/quic/node_quic_http3_application.cc
@@ -4,7 +4,7 @@
 #include "node_quic_buffer-inl.h"
 #include "node_quic_http3_application.h"
 #include "node_quic_session-inl.h"
-#include "node_quic_socket.h"
+#include "node_quic_socket-inl.h"
 #include "node_quic_stream-inl.h"
 #include "node_quic_util-inl.h"
 #include "node_sockaddr-inl.h"

--- a/src/quic/node_quic_session-inl.h
+++ b/src/quic/node_quic_session-inl.h
@@ -8,7 +8,7 @@
 #include "node_crypto_common.h"
 #include "node_quic_crypto.h"
 #include "node_quic_session.h"
-#include "node_quic_socket.h"
+#include "node_quic_socket-inl.h"
 #include "node_quic_stream-inl.h"
 
 #include <openssl/ssl.h>
@@ -352,6 +352,10 @@ bool QuicSession::is_gracefully_closing() const {
 
 bool QuicSession::is_destroyed() const {
   return is_flag_set(QUICSESSION_FLAG_DESTROYED);
+}
+
+bool QuicSession::is_stateless_reset() const {
+  return is_flag_set(QUICSESSION_FLAG_STATELESS_RESET);
 }
 
 bool QuicSession::is_server() const {

--- a/src/quic/node_quic_session.cc
+++ b/src/quic/node_quic_session.cc
@@ -120,7 +120,6 @@ void QuicSessionConfig::Set(
     Environment* env,
     const sockaddr* preferred_addr) {
   ResetToDefaults(env);
-
   SetConfig(env, IDX_QUIC_SESSION_ACTIVE_CONNECTION_ID_LIMIT,
             &transport_params.active_connection_id_limit);
   SetConfig(env, IDX_QUIC_SESSION_MAX_STREAM_DATA_BIDI_LOCAL,
@@ -142,7 +141,7 @@ void QuicSessionConfig::Set(
   SetConfig(env, IDX_QUIC_SESSION_MAX_ACK_DELAY,
             &transport_params.max_ack_delay);
 
-  transport_params.idle_timeout = transport_params.idle_timeout * 1000000;
+  transport_params.idle_timeout = transport_params.idle_timeout * 1000000000;
 
   // TODO(@jasnell): QUIC allows both IPv4 and IPv6 addresses to be
   // specified. Here we're specifying one or the other. Need to
@@ -2495,7 +2494,7 @@ void QuicSession::UpdateIdleTimer() {
   uint64_t now = uv_hrtime();
   uint64_t expiry = ngtcp2_conn_get_idle_expiry(connection());
   // nano to millis
-  uint64_t timeout = expiry > now ? (expiry - now) / 1e6 : 1;
+  uint64_t timeout = expiry > now ? (expiry - now) / 1000000ULL : 1;
   if (timeout == 0) timeout = 1;
   Debug(this, "Updating idle timeout to %" PRIu64, timeout);
   idle_->Update(timeout);

--- a/src/quic/node_quic_socket-inl.h
+++ b/src/quic/node_quic_socket-inl.h
@@ -1,0 +1,223 @@
+#ifndef SRC_QUIC_NODE_QUIC_SOCKET_INL_H_
+#define SRC_QUIC_NODE_QUIC_SOCKET_INL_H_
+
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
+#include "node_quic_socket.h"
+#include "node_sockaddr.h"
+#include "node_quic_session.h"
+#include "node_crypto.h"
+#include "debug_utils.h"
+
+namespace node {
+
+using crypto::EntropySource;
+
+namespace quic {
+
+std::unique_ptr<QuicPacket> QuicPacket::Create(
+    const char* diagnostic_label,
+    size_t len) {
+  return std::make_unique<QuicPacket>(diagnostic_label, len);
+}
+
+std::unique_ptr<QuicPacket> QuicPacket::Copy(
+    const std::unique_ptr<QuicPacket>& other) {
+  return std::make_unique<QuicPacket>(*other.get());
+}
+
+void QuicPacket::set_length(size_t len) {
+  CHECK_LE(len, data_.size());
+  data_.resize(len);
+}
+
+int QuicEndpoint::Send(
+    uv_buf_t* buf,
+    size_t len,
+    const sockaddr* addr) {
+  int ret = static_cast<int>(udp_->Send(buf, len, addr));
+  if (ret == 0)
+    IncrementPendingCallbacks();
+  return ret;
+}
+
+int QuicEndpoint::ReceiveStart() {
+  return udp_->RecvStart();
+}
+
+int QuicEndpoint::ReceiveStop() {
+  return udp_->RecvStop();
+}
+
+void QuicEndpoint::WaitForPendingCallbacks() {
+  if (!has_pending_callbacks()) {
+    listener_->OnEndpointDone(this);
+    return;
+  }
+  waiting_for_callbacks_ = true;
+}
+
+void QuicSocket::AssociateCID(
+    const QuicCID& cid,
+    const QuicCID& scid) {
+  dcid_to_scid_[cid] = scid;
+}
+
+void QuicSocket::DisassociateCID(const QuicCID& cid) {
+  Debug(this, "Removing association for cid %s", cid.ToHex().c_str());
+  dcid_to_scid_.erase(cid);
+}
+
+void QuicSocket::AssociateStatelessResetToken(
+    const StatelessResetToken& token,
+    BaseObjectPtr<QuicSession> session) {
+  Debug(this, "Associating stateless reset token %s", token.ToHex().c_str());
+  token_map_[token] = session;
+}
+
+void QuicSocket::DisassociateStatelessResetToken(
+    const StatelessResetToken& token) {
+  Debug(this, "Removing stateless reset token %s", token.ToHex().c_str());
+  token_map_.erase(token);
+}
+
+// StopListening is called when the QuicSocket is no longer
+// accepting new server connections. Typically, this is called
+// when the QuicSocket enters a graceful closing state where
+// existing sessions are allowed to close naturally but new
+// sessions are rejected.
+void QuicSocket::StopListening() {
+  if (!is_flag_set(QUICSOCKET_FLAGS_SERVER_LISTENING))
+    return;
+  Debug(this, "Stop listening.");
+  set_flag(QUICSOCKET_FLAGS_SERVER_LISTENING, false);
+  // It is important to not call ReceiveStop here as there
+  // is ongoing traffic being exchanged by the peers.
+}
+
+void QuicSocket::ReceiveStart() {
+  for (const auto& endpoint : endpoints_)
+    CHECK_EQ(endpoint->ReceiveStart(), 0);
+}
+
+void QuicSocket::ReceiveStop() {
+  for (const auto& endpoint : endpoints_)
+    CHECK_EQ(endpoint->ReceiveStop(), 0);
+}
+
+void QuicSocket::RemoveSession(
+    const QuicCID& cid,
+    const SocketAddress& addr) {
+  sessions_.erase(cid);
+  DecrementSocketAddressCounter(addr);
+}
+
+void QuicSocket::ReportSendError(int error) {
+  listener_->OnError(error);
+}
+
+void QuicSocket::IncrementStatelessResetCounter(const SocketAddress& addr) {
+  reset_counts_[addr]++;
+}
+
+void QuicSocket::IncrementSocketAddressCounter(const SocketAddress& addr) {
+  addr_counts_[addr]++;
+}
+
+void QuicSocket::DecrementSocketAddressCounter(const SocketAddress& addr) {
+  auto it = addr_counts_.find(addr);
+  if (it == std::end(addr_counts_))
+    return;
+  it->second--;
+  // Remove the address if the counter reaches zero again.
+  if (it->second == 0) {
+    addr_counts_.erase(addr);
+    reset_counts_.erase(addr);
+  }
+}
+
+size_t QuicSocket::GetCurrentSocketAddressCounter(const sockaddr* addr) {
+  auto it = addr_counts_.find(SocketAddress(addr));
+  if (it == std::end(addr_counts_))
+    return 0;
+  return it->second;
+}
+
+size_t QuicSocket::GetCurrentStatelessResetCounter(const sockaddr* addr) {
+  auto it = reset_counts_.find(SocketAddress(addr));
+  if (it == std::end(reset_counts_))
+    return 0;
+  return it->second;
+}
+
+void QuicSocket::set_server_busy(bool on) {
+  Debug(this, "Turning Server Busy Response %s", on ? "on" : "off");
+  set_flag(QUICSOCKET_FLAGS_SERVER_BUSY, on);
+  listener_->OnServerBusy(on);
+}
+
+bool QuicSocket::is_diagnostic_packet_loss(double prob) const {
+  if (LIKELY(prob == 0.0)) return false;
+  unsigned char c = 255;
+  EntropySource(&c, 1);
+  return (static_cast<double>(c) / 255) < prob;
+}
+
+void QuicSocket::set_diagnostic_packet_loss(double rx, double tx) {
+  rx_loss_ = rx;
+  tx_loss_ = tx;
+}
+
+bool QuicSocket::ToggleStatelessReset() {
+  set_flag(
+      QUICSOCKET_FLAGS_DISABLE_STATELESS_RESET,
+      !is_flag_set(QUICSOCKET_FLAGS_DISABLE_STATELESS_RESET));
+  return !is_flag_set(QUICSOCKET_FLAGS_DISABLE_STATELESS_RESET);
+}
+
+void QuicSocket::set_validated_address(const sockaddr* addr) {
+  if (is_option_set(QUICSOCKET_OPTIONS_VALIDATE_ADDRESS_LRU)) {
+    // Remove the oldest item if we've hit the LRU limit
+    validated_addrs_.push_back(SocketAddress::Hash()(addr));
+    if (validated_addrs_.size() > MAX_VALIDATE_ADDRESS_LRU)
+      validated_addrs_.pop_front();
+  }
+}
+
+bool QuicSocket::is_validated_address(const sockaddr* addr) const {
+  if (is_option_set(QUICSOCKET_OPTIONS_VALIDATE_ADDRESS_LRU)) {
+    auto res = std::find(std::begin(validated_addrs_),
+                         std::end(validated_addrs_),
+                         SocketAddress::Hash()(addr));
+    return res != std::end(validated_addrs_);
+  }
+  return false;
+}
+
+void QuicSocket::AddSession(
+    const QuicCID& cid,
+    BaseObjectPtr<QuicSession> session) {
+  sessions_[cid] = session;
+  IncrementSocketAddressCounter(session->remote_address());
+  IncrementSocketStat(
+      1, &socket_stats_,
+      session->is_server() ?
+          &socket_stats::server_sessions :
+          &socket_stats::client_sessions);
+}
+
+void QuicSocket::AddEndpoint(QuicEndpoint* endpoint_, bool preferred) {
+  Debug(this, "Adding %sendpoint.", preferred ? "preferred " : "");
+  if (preferred || endpoints_.empty())
+    preferred_endpoint_ = endpoint_;
+  endpoints_.emplace_back(endpoint_);
+  if (is_flag_set(QUICSOCKET_FLAGS_SERVER_LISTENING))
+    endpoint_->ReceiveStart();
+}
+
+}  // namespace quic
+}  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
+#endif  // SRC_QUIC_NODE_QUIC_SOCKET_INL_H_

--- a/src/quic/node_quic_stream-inl.h
+++ b/src/quic/node_quic_stream-inl.h
@@ -3,6 +3,7 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
+#include "debug_utils.h"
 #include "node_quic_session.h"
 #include "node_quic_stream.h"
 #include "node_quic_buffer-inl.h"

--- a/src/quic/node_quic_stream.cc
+++ b/src/quic/node_quic_stream.cc
@@ -1,3 +1,4 @@
+#include "node_quic_stream-inl.h"  // NOLINT(build/include)
 #include "async_wrap-inl.h"
 #include "debug_utils.h"
 #include "env-inl.h"
@@ -6,8 +7,7 @@
 #include "node_internals.h"
 #include "stream_base-inl.h"
 #include "node_quic_session-inl.h"
-#include "node_quic_stream-inl.h"
-#include "node_quic_socket.h"
+#include "node_quic_socket-inl.h"
 #include "node_quic_util-inl.h"
 #include "v8.h"
 #include "uv.h"

--- a/src/quic/node_quic_util.h
+++ b/src/quic/node_quic_util.h
@@ -37,7 +37,7 @@ constexpr uint64_t DEFAULT_MAX_STREAM_DATA_UNI = 256 * 1024;
 constexpr uint64_t DEFAULT_MAX_DATA = 1 * 1024 * 1024;
 constexpr uint64_t DEFAULT_MAX_STREAMS_BIDI = 100;
 constexpr uint64_t DEFAULT_MAX_STREAMS_UNI = 3;
-constexpr uint64_t DEFAULT_IDLE_TIMEOUT = 10 * 10000000000;
+constexpr uint64_t DEFAULT_IDLE_TIMEOUT = 10;
 constexpr uint64_t DEFAULT_RETRYTOKEN_EXPIRATION = 10ULL;
 
 enum SelectPreferredAddressPolicy : int {

--- a/test/parallel/test-quic-statelessreset.js
+++ b/test/parallel/test-quic-statelessreset.js
@@ -1,0 +1,73 @@
+// Flags: --expose-internals --no-warnings
+'use strict';
+
+// Testing stateless reset
+
+const common = require('../common');
+if (!common.hasQuic)
+  common.skip('missing quic');
+
+const { internalBinding } = require('internal/test/binding');
+const assert = require('assert');
+const fixtures = require('../common/fixtures');
+const key = fixtures.readKey('agent1-key.pem', 'binary');
+const cert = fixtures.readKey('agent1-cert.pem', 'binary');
+const ca = fixtures.readKey('ca1-cert.pem', 'binary');
+
+const {
+  kHandle,
+} = require('internal/stream_base_commons');
+const { silentCloseSession } = internalBinding('quic');
+
+const { createSocket } = require('quic');
+
+const kStatelessResetToken =
+  Buffer.from('000102030405060708090A0B0C0D0E0F', 'hex');
+
+let client;
+
+const server = createSocket({ statelessResetSecret: kStatelessResetToken });
+
+server.listen({ key, cert, ca, alpn: 'zzz' });
+
+server.on('session', common.mustCall((session) => {
+  session.on('stream', common.mustCall((stream) => {
+    // silentCloseSession is an internal-only testing tool
+    // that allows us to prematurely destroy a QuicSession
+    // without the proper communication flow with the connected
+    // peer. We call this to simulate a local crash that loses
+    // state, which should trigger the server to send a
+    // stateless reset token to the client.
+    silentCloseSession(session[kHandle]);
+  }));
+
+  session.on('close', common.mustCall());
+}));
+
+server.on('ready', common.mustCall(() => {
+  const endpoint = server.endpoints[0];
+
+  client = createSocket({ client: { key, cert, ca, alpn: 'zzz' } });
+
+  client.on('close', common.mustCall());
+
+  const req = client.connect({
+    address: 'localhost',
+    port: endpoint.address.port,
+    servername: 'localhost',
+  });
+
+  req.on('secure', common.mustCall((servername, alpn, cipher) => {
+    const stream = req.openStream();
+    stream.end('hello');
+    stream.resume();
+    stream.on('close', common.mustCall());
+  }));
+
+  req.on('close', common.mustCall(() => {
+    assert.strictEqual(req.statelessReset, true);
+    server.close();
+    client.close();
+  }));
+
+}));


### PR DESCRIPTION
Fixes sending and receiving of stateless reset tokens.

This is currently a work in progress pending resolution of a discussion over in the ngtcp2 repo: https://github.com/ngtcp2/ngtcp2/issues/206