### PR TITLE
quic: various cleanups in quic_crypto

### DIFF
--- a/src/quic/node_quic_socket.cc
+++ b/src/quic/node_quic_socket.cc
@@ -258,20 +258,18 @@ QuicSocket::QuicSocket(
 
   Debug(this, "New QuicSocket created.");
 
-  EntropySource(token_secret_.data(), token_secret_.size());
+  EntropySource(token_secret_, TOKEN_SECRETLEN);
   socket_stats_.created_at = uv_hrtime();
 
   // Set the session reset secret to the one provided or random.
   // Note that a random secret is going to make it exceedingly
   // difficult for the session reset token to be useful.
   if (session_reset_secret != nullptr) {
-    memcpy(reset_token_secret_.data(),
+    memcpy(reset_token_secret_,
            session_reset_secret,
-           reset_token_secret_.size());
+           NGTCP2_STATELESS_RESET_TOKENLEN);
   } else {
-    EntropySource(
-        reset_token_secret_.data(),
-        reset_token_secret_.size());
+    EntropySource(reset_token_secret_, NGTCP2_STATELESS_RESET_TOKENLEN);
   }
 
   USE(wrap->DefineOwnProperty(
@@ -779,10 +777,10 @@ BaseObjectPtr<QuicSession> QuicSocket::AcceptInitialPacket(
     if (!IsValidatedAddress(remote_addr)) {
       Debug(this, "Performing explicit address validation.");
       if (InvalidRetryToken(
-              env(),
-              &ocid,
-              &hd,
+              hd.token,
+              hd.tokenlen,
               remote_addr,
+              &ocid,
               token_secret_,
               retry_token_expiration_)) {
         Debug(this, "A valid retry token was not found. Sending retry.");

--- a/src/quic/node_quic_socket.h
+++ b/src/quic/node_quic_socket.h
@@ -325,7 +325,7 @@ class QuicSocket : public AsyncWrap,
   void IncreaseAllocatedSize(size_t size);
   void DecreaseAllocatedSize(size_t size);
 
-  const ResetTokenSecret& GetSessionResetSecret() {
+  const uint8_t* GetSessionResetSecret() {
     return reset_token_secret_;
   }
 
@@ -458,8 +458,9 @@ class QuicSocket : public AsyncWrap,
   std::string server_alpn_;
   std::unordered_map<std::string, BaseObjectPtr<QuicSession>> sessions_;
   std::unordered_map<std::string, std::string> dcid_to_scid_;
-  RetryTokenSecret token_secret_;
-  ResetTokenSecret reset_token_secret_;
+
+  uint8_t token_secret_[TOKEN_SECRETLEN];
+  uint8_t reset_token_secret_[NGTCP2_STATELESS_RESET_TOKENLEN];
 
   // Counts the number of active connections per remote
   // address. A custom std::hash specialization for

--- a/src/quic/node_quic_util.h
+++ b/src/quic/node_quic_util.h
@@ -39,9 +39,6 @@ constexpr uint64_t DEFAULT_MAX_STREAMS_UNI = 3;
 constexpr uint64_t DEFAULT_IDLE_TIMEOUT = 10 * 10000000000;
 constexpr uint64_t DEFAULT_RETRYTOKEN_EXPIRATION = 10ULL;
 
-using RetryTokenSecret = std::array<uint8_t, TOKEN_SECRETLEN>;
-using ResetTokenSecret = std::array<uint8_t, NGTCP2_STATELESS_RESET_TOKENLEN>;
-
 enum SelectPreferredAddressPolicy : int {
   // Ignore the server-provided preferred address
   QUIC_PREFERRED_ADDRESS_IGNORE,


### PR DESCRIPTION
Mainly: using arrays directly instead of std::array where appropriate
