### PR TITLE
quic: refactoring SendPendingData

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -853,6 +853,7 @@
             'src/quic/node_quic_session-inl.h',
             'src/quic/node_quic_socket.h',
             'src/quic/node_quic_stream.h',
+            'src/quic/node_quic_stream-inl.h',
             'src/quic/node_quic_util.h',
             'src/quic/node_quic_util-inl.h',
             'src/quic/node_quic_state.h',

--- a/src/quic/node_quic.cc
+++ b/src/quic/node_quic.cc
@@ -9,7 +9,7 @@
 #include "node_quic_crypto.h"
 #include "node_quic_session-inl.h"
 #include "node_quic_socket.h"
-#include "node_quic_stream.h"
+#include "node_quic_stream-inl.h"
 #include "node_quic_state.h"
 #include "node_quic_util-inl.h"
 #include "node_sockaddr-inl.h"

--- a/src/quic/node_quic_default_application.cc
+++ b/src/quic/node_quic_default_application.cc
@@ -135,10 +135,10 @@ bool DefaultApplication::SendStreamData(QuicStream* stream) {
   ssize_t ndatalen = 0;
   QuicPathStorage path;
   Debug(session(), "Default QUIC Application sending stream %" PRId64 " data",
-        stream->GetID());
+        stream->id());
 
   StreamData stream_data;
-  stream_data.id = stream->GetID();
+  stream_data.id = stream->id();
   stream_data.user_data = stream;
   GetStreamData(&stream_data);
 
@@ -176,7 +176,7 @@ bool DefaultApplication::SendStreamData(QuicStream* stream) {
           session()->SilentClose();
           return false;
         case NGTCP2_ERR_STREAM_DATA_BLOCKED:
-          session()->StreamDataBlocked(stream->GetID());
+          session()->StreamDataBlocked(stream->id());
           if (session()->max_data_left() == 0)
             goto congestion_limited;
           return true;

--- a/src/quic/node_quic_default_application.cc
+++ b/src/quic/node_quic_default_application.cc
@@ -3,7 +3,7 @@
 #include "node_quic_default_application.h"
 #include "node_quic_session-inl.h"
 #include "node_quic_socket.h"
-#include "node_quic_stream.h"
+#include "node_quic_stream-inl.h"
 #include "node_quic_util-inl.h"
 #include "node_sockaddr-inl.h"
 #include <ngtcp2/ngtcp2.h>
@@ -68,7 +68,7 @@ void DefaultApplication::AcknowledgeStreamData(
   // It's possible that the stream has already been destroyed and
   // removed. If so, just silently ignore the ack
   if (stream != nullptr)
-    stream->AckedDataOffset(offset, datalen);
+    stream->Acknowledge(offset, datalen);
 }
 
 bool DefaultApplication::SendPendingData() {

--- a/src/quic/node_quic_default_application.cc
+++ b/src/quic/node_quic_default_application.cc
@@ -209,7 +209,7 @@ bool DefaultApplication::SendStreamData(QuicStream* stream) {
     packet.reset();
     pos = nullptr;
 
-    if (ShouldSetFin(&stream_data))
+    if (ShouldSetFin(stream_data))
       set_stream_fin(stream_data.id);
 
     if (IsEmpty(stream_data.buf, stream_data.count))
@@ -240,10 +240,10 @@ bool DefaultApplication::StreamCommit(
   return true;
 }
 
-bool DefaultApplication::ShouldSetFin(StreamData* stream_data) {
-  if (!IsEmpty(stream_data->buf, stream_data->count))
+bool DefaultApplication::ShouldSetFin(const StreamData& stream_data) {
+  if (!IsEmpty(stream_data.buf, stream_data.count))
     return false;
-  QuicStream* stream = static_cast<QuicStream*>(stream_data->user_data);
+  QuicStream* stream = static_cast<QuicStream*>(stream_data.user_data);
   return !stream->is_writable();
 }
 

--- a/src/quic/node_quic_default_application.cc
+++ b/src/quic/node_quic_default_application.cc
@@ -13,16 +13,69 @@
 namespace node {
 namespace quic {
 
+namespace {
+void Consume(ngtcp2_vec** pvec, size_t* pcnt, size_t len) {
+  ngtcp2_vec* v = *pvec;
+  size_t cnt = *pcnt;
+
+  for (; cnt > 0; --cnt, ++v) {
+    if (v->len > len) {
+      v->len -= len;
+      v->base += len;
+      break;
+    }
+    len -= v->len;
+  }
+
+  *pvec = v;
+  *pcnt = cnt;
+}
+
+int IsEmpty(const ngtcp2_vec* vec, size_t cnt) {
+  size_t i;
+  for (i = 0; i < cnt && vec[i].len == 0; ++i) {}
+  return i == cnt;
+}
+}  // anonymous namespace
+
 DefaultApplication::DefaultApplication(
     QuicSession* session) :
     QuicApplication(session) {}
 
 bool DefaultApplication::Initialize() {
-  if (!needs_init())
-    return false;
-  Debug(session(), "Default QUIC Application Initialized");
-  set_init_done();
-  return true;
+  if (needs_init()) {
+    Debug(session(), "Default QUIC Application Initialized");
+    set_init_done();
+  }
+  return needs_init();
+}
+
+void DefaultApplication::ScheduleStream(int64_t stream_id) {
+  QuicStream* stream = session()->FindStream(stream_id);
+  Debug(session(), "Scheduling stream %" PRIu64, stream_id);
+  if (stream != nullptr)
+    stream->Schedule(&stream_queue_);
+}
+
+void DefaultApplication::UnscheduleStream(int64_t stream_id) {
+  QuicStream* stream = session()->FindStream(stream_id);
+  Debug(session(), "Unscheduling stream %" PRIu64, stream_id);
+  if (stream != nullptr)
+    stream->Unschedule();
+}
+
+void DefaultApplication::StreamClose(
+    int64_t stream_id,
+    uint64_t app_error_code) {
+  if (app_error_code == 0)
+    app_error_code = NGTCP2_APP_NOERROR;
+  UnscheduleStream(stream_id);
+  QuicApplication::StreamClose(stream_id, app_error_code);
+}
+
+void DefaultApplication::ResumeStream(int64_t stream_id) {
+  Debug(session(), "Stream %" PRId64 " has data to send");
+  ScheduleStream(stream_id);
 }
 
 bool DefaultApplication::ReceiveStreamData(
@@ -59,70 +112,28 @@ bool DefaultApplication::ReceiveStreamData(
   return true;
 }
 
-void DefaultApplication::AcknowledgeStreamData(
-    int64_t stream_id,
-    uint64_t offset,
-    size_t datalen) {
-  QuicStream* stream = session()->FindStream(stream_id);
-  Debug(session(), "Default QUIC Application acknowledging stream data");
-  // It's possible that the stream has already been destroyed and
-  // removed. If so, just silently ignore the ack
-  if (stream != nullptr)
-    stream->Acknowledge(offset, datalen);
-}
-
-bool DefaultApplication::SendPendingData() {
-  // Right now this iterates through the streams in the order they
-  // were created. Later, we might want to implement a prioritization
-  // scheme to allow higher priority streams to be serialized first.
-  // Prioritization is left entirely up to the application layer in QUIC.
-  // HTTP/3, for instance, drops prioritization entirely.
-  Debug(session(), "Default QUIC Application sending pending data");
-  for (const auto& stream : session()->streams()) {
-    if (!SendStreamData(stream.second.get()))
-      return false;
-
-    // Check to make sure QuicSession state did not change in this iteration
-    if (session()->is_in_draining_period() ||
-        session()->is_in_closing_period() ||
-        session()->is_destroyed()) {
-      break;
-    }
-  }
-
-  return true;
-}
-
-namespace {
-void Consume(ngtcp2_vec** pvec, size_t* pcnt, size_t len) {
-  ngtcp2_vec* v = *pvec;
-  size_t cnt = *pcnt;
-
-  for (; cnt > 0; --cnt, ++v) {
-    if (v->len > len) {
-      v->len -= len;
-      v->base += len;
-      break;
-    }
-    len -= v->len;
-  }
-
-  *pvec = v;
-  *pcnt = cnt;
-}
-
-int IsEmpty(const ngtcp2_vec* vec, size_t cnt) {
-  size_t i;
-  for (i = 0; i < cnt && vec[i].len == 0; ++i) {}
-  return i == cnt;
-}
-}  // anonymous namespace
-
 int DefaultApplication::GetStreamData(StreamData* stream_data) {
-  QuicStream* stream = session()->FindStream(stream_data->id);
+  QuicStream* stream = stream_queue_.PopFront();
+  // If stream is nullptr, there are no streams with data pending.
+  if (stream == nullptr)
+    return 0;
+
   stream_data->remaining =
-    stream->DrainInto(&stream_data->data, &stream_data->count, 16);
+      stream->DrainInto(
+          &stream_data->data,
+          &stream_data->count,
+          MAX_VECTOR_COUNT);
+
+  stream_data->user_data = stream;
+  stream_data->id = stream->id();
   stream_data->fin = stream->is_writable() ? 0 : 1;
+
+  // Schedule the stream again only if there is data to write. There
+  // might not actually be any more data to write but we can't know
+  // that yet as it depends entirely on how much data actually gets
+  // serialized by ngtcp2.
+  if (stream_data->count > 0)
+    ScheduleStream(stream->id());
 
   Debug(session(), "Selected %" PRId64 " buffers for stream %" PRId64 "%s",
         stream_data->count,
@@ -131,109 +142,11 @@ int DefaultApplication::GetStreamData(StreamData* stream_data) {
   return 0;
 }
 
-bool DefaultApplication::SendStreamData(QuicStream* stream) {
-  ssize_t ndatalen = 0;
-  QuicPathStorage path;
-  Debug(session(), "Default QUIC Application sending stream %" PRId64 " data",
-        stream->id());
-
-  StreamData stream_data;
-  stream_data.id = stream->id();
-  stream_data.user_data = stream;
-  GetStreamData(&stream_data);
-
-  // If there is no stream data and we're not sending fin,
-  // Just return without doing anything.
-  if (stream_data.count == 0 && !stream_data.fin) {
-    Debug(stream, "There is no stream data to send");
-    return true;
-  }
-
-  std::unique_ptr<QuicPacket> packet = CreateStreamDataPacket();
-  uint8_t* pos = packet->data();
-
-  for (;;) {
-    // If packet was sent on the previous iteration, it will have been reset
-    if (!packet) {
-      packet = CreateStreamDataPacket();
-      pos = packet->data();
-    }
-
-    ssize_t nwrite = WriteVStream(&path, pos, &ndatalen, stream_data);
-
-    if (nwrite <= 0) {
-      switch (nwrite) {
-        case 0:
-          goto congestion_limited;
-        case NGTCP2_ERR_PKT_NUM_EXHAUSTED:
-          // There is a finite number of packets that can be sent
-          // per connection. Once those are exhausted, there's
-          // absolutely nothing we can do except immediately
-          // and silently tear down the QuicSession. This has
-          // to be silent because we can't even send a
-          // CONNECTION_CLOSE since even those require a
-          // packet number.
-          session()->SilentClose();
-          return false;
-        case NGTCP2_ERR_STREAM_DATA_BLOCKED:
-          session()->StreamDataBlocked(stream->id());
-          if (session()->max_data_left() == 0)
-            goto congestion_limited;
-          return true;
-        case NGTCP2_ERR_STREAM_SHUT_WR:
-          if (UNLIKELY(!BlockStream(stream_data.id)))
-            return false;
-          return true;
-        case NGTCP2_ERR_STREAM_NOT_FOUND:
-          return true;
-        case NGTCP2_ERR_WRITE_STREAM_MORE:
-          CHECK_GT(ndatalen, 0);
-          CHECK(StreamCommit(&stream_data, ndatalen));
-          pos += ndatalen;
-          continue;
-      }
-      session()->set_last_error(QUIC_ERROR_SESSION, static_cast<int>(nwrite));
-      return false;
-    }
-
-    pos += nwrite;
-
-    if (ndatalen >= 0)
-      CHECK(StreamCommit(&stream_data, ndatalen));
-
-    Debug(stream, "Sending %" PRIu64 " bytes in serialized packet", nwrite);
-    packet->set_length(nwrite);
-    if (!session()->SendPacket(std::move(packet), path))
-      return false;
-
-    packet.reset();
-    pos = nullptr;
-
-    if (ShouldSetFin(stream_data))
-      set_stream_fin(stream_data.id);
-
-    if (IsEmpty(stream_data.buf, stream_data.count))
-      break;
-  }
-
-  return true;
-
- congestion_limited:
-  if (pos - packet->data()) {
-    // Some data was serialized into the packet. We need to send it.
-    packet->set_length(pos - packet->data());
-    Debug(session(), "Congestion limited, but %" PRIu64 " bytes pending.",
-          packet->length());
-    if (!session()->SendPacket(std::move(packet), path))
-      return false;
-  }
-  return true;
-}
-
 bool DefaultApplication::StreamCommit(
     StreamData* stream_data,
     size_t datalen) {
   QuicStream* stream = static_cast<QuicStream*>(stream_data->user_data);
+  CHECK_NOT_NULL(stream);
   stream_data->remaining -= datalen;
   Consume(&stream_data->buf, &stream_data->count, datalen);
   stream->Commit(datalen);
@@ -241,7 +154,8 @@ bool DefaultApplication::StreamCommit(
 }
 
 bool DefaultApplication::ShouldSetFin(const StreamData& stream_data) {
-  if (!IsEmpty(stream_data.buf, stream_data.count))
+  if (stream_data.user_data == nullptr ||
+      !IsEmpty(stream_data.buf, stream_data.count))
     return false;
   QuicStream* stream = static_cast<QuicStream*>(stream_data.user_data);
   return !stream->is_writable();

--- a/src/quic/node_quic_default_application.h
+++ b/src/quic/node_quic_default_application.h
@@ -38,7 +38,7 @@ class DefaultApplication final : public QuicApplication {
 
   int GetStreamData(StreamData* stream_data) override;
   bool StreamCommit(StreamData* stream_data, size_t datalen) override;
-  bool ShouldSetFin(StreamData* stream_data) override;
+  bool ShouldSetFin(const StreamData& stream_data) override;
 
   SET_SELF_SIZE(DefaultApplication)
   SET_MEMORY_INFO_NAME(DefaultApplication)

--- a/src/quic/node_quic_default_application.h
+++ b/src/quic/node_quic_default_application.h
@@ -3,8 +3,10 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
+#include "node_quic_stream.h"
 #include "node_quic_session.h"
 #include "node_quic_util.h"
+#include "util.h"
 #include "v8.h"
 
 namespace node {
@@ -28,21 +30,23 @@ class DefaultApplication final : public QuicApplication {
       const uint8_t* data,
       size_t datalen,
       uint64_t offset) override;
-  void AcknowledgeStreamData(
-      int64_t stream_id,
-      uint64_t offset,
-      size_t datalen) override;
-
-  bool SendPendingData() override;
-  bool SendStreamData(QuicStream* stream) override;
 
   int GetStreamData(StreamData* stream_data) override;
-  bool StreamCommit(StreamData* stream_data, size_t datalen) override;
+
+  void ResumeStream(int64_t stream_id) override;
+  void StreamClose(int64_t stream_id, uint64_t app_error_code) override;
   bool ShouldSetFin(const StreamData& stream_data) override;
+  bool StreamCommit(StreamData* stream_data, size_t datalen) override;
 
   SET_SELF_SIZE(DefaultApplication)
   SET_MEMORY_INFO_NAME(DefaultApplication)
   SET_NO_MEMORY_INFO()
+
+ private:
+  void ScheduleStream(int64_t stream_id);
+  void UnscheduleStream(int64_t stream_id);
+
+  QuicStream::Queue stream_queue_;
 };
 
 }  // namespace quic

--- a/src/quic/node_quic_default_application.h
+++ b/src/quic/node_quic_default_application.h
@@ -36,6 +36,10 @@ class DefaultApplication final : public QuicApplication {
   bool SendPendingData() override;
   bool SendStreamData(QuicStream* stream) override;
 
+  int GetStreamData(StreamData* stream_data) override;
+  bool StreamCommit(StreamData* stream_data, size_t datalen) override;
+  bool ShouldSetFin(StreamData* stream_data) override;
+
   SET_SELF_SIZE(DefaultApplication)
   SET_MEMORY_INFO_NAME(DefaultApplication)
   SET_NO_MEMORY_INFO()

--- a/src/quic/node_quic_http3_application.cc
+++ b/src/quic/node_quic_http3_application.cc
@@ -594,7 +594,7 @@ bool Http3Application::ShouldSetFin(const StreamData& stream_data) {
 
 bool Http3Application::SendStreamData(QuicStream* stream) {
   // Data is available now, so resume the stream.
-  nghttp3_conn_resume_stream(connection(), stream->GetID());
+  nghttp3_conn_resume_stream(connection(), stream->id());
   return SendPendingData();
 }
 

--- a/src/quic/node_quic_http3_application.h
+++ b/src/quic/node_quic_http3_application.h
@@ -143,7 +143,7 @@ class Http3Application final :
 
   bool BlockStream(int64_t stream_id) override;
   bool StreamCommit(StreamData* stream_data, size_t datalen) override;
-  bool ShouldSetFin(StreamData* data) override;
+  bool ShouldSetFin(const StreamData& data) override;
 
   ssize_t H3ReadData(
       int64_t stream_id,

--- a/src/quic/node_quic_http3_application.h
+++ b/src/quic/node_quic_http3_application.h
@@ -139,8 +139,11 @@ class Http3Application final :
   bool CreateAndBindControlStream();
   bool CreateAndBindQPackStreams();
 
-  bool StreamCommit(int64_t stream_id, ssize_t datalen);
-  void set_stream_fin(int64_t stream_id);
+  int GetStreamData(StreamData* stream_data) override;
+
+  bool BlockStream(int64_t stream_id) override;
+  bool StreamCommit(StreamData* stream_data, size_t datalen) override;
+  bool ShouldSetFin(StreamData* data) override;
 
   ssize_t H3ReadData(
       int64_t stream_id,

--- a/src/quic/node_quic_http3_application.h
+++ b/src/quic/node_quic_http3_application.h
@@ -7,7 +7,7 @@
 #include "node_http_common.h"
 #include "node_mem.h"
 #include "node_quic_session.h"
-#include "node_quic_stream.h"
+#include "node_quic_stream-inl.h"
 #include "node_quic_util.h"
 #include "v8.h"
 #include <ngtcp2/ngtcp2.h>
@@ -67,6 +67,10 @@ class Http3Header : public QuicHeader {
 
   size_t length() const override;
 
+  void MemoryInfo(MemoryTracker* tracker) const override;
+  SET_MEMORY_INFO_NAME(Http3Header)
+  SET_SELF_SIZE(Http3Header)
+
  private:
   int32_t token_ = -1;
   Http3RcBufferPointer name_;
@@ -103,6 +107,8 @@ class Http3Application final :
       int64_t stream_id,
       uint64_t final_size,
       uint64_t app_error_code) override;
+
+  void ResumeStream(int64_t stream_id) override;
 
   void ExtendMaxStreamsRemoteUni(uint64_t max_streams) override;
   void ExtendMaxStreamData(int64_t stream_id, uint64_t max_data) override;

--- a/src/quic/node_quic_http3_application.h
+++ b/src/quic/node_quic_http3_application.h
@@ -151,39 +151,39 @@ class Http3Application final :
   bool StreamCommit(StreamData* stream_data, size_t datalen) override;
   bool ShouldSetFin(const StreamData& data) override;
 
-  ssize_t H3ReadData(
+  ssize_t ReadData(
       int64_t stream_id,
       nghttp3_vec* vec,
       size_t veccnt,
       uint32_t* pflags);
 
-  void H3AckedStreamData(int64_t stream_id, size_t datalen);
-  void H3StreamClose(int64_t stream_id, uint64_t app_error_code);
-  void H3ReceiveData(int64_t stream_id, const uint8_t* data, size_t datalen);
-  void H3DeferredConsume(int64_t stream_id, size_t consumed);
-  void H3BeginHeaders(
+  void AckedStreamData(int64_t stream_id, size_t datalen);
+  void StreamClosed(int64_t stream_id, uint64_t app_error_code);
+  void ReceiveData(int64_t stream_id, const uint8_t* data, size_t datalen);
+  void DeferredConsume(int64_t stream_id, size_t consumed);
+  void BeginHeaders(
       int64_t stream_id,
       QuicStreamHeadersKind kind = QUICSTREAM_HEADERS_KIND_NONE);
-  bool H3ReceiveHeader(
+  bool ReceiveHeader(
       int64_t stream_id,
       int32_t token,
       nghttp3_rcbuf* name,
       nghttp3_rcbuf* value,
       uint8_t flags);
-  void H3EndHeaders(int64_t stream_id);
-  int H3BeginPushPromise(int64_t stream_id, int64_t push_id);
-  bool H3ReceivePushPromise(
+  void EndHeaders(int64_t stream_id);
+  int BeginPushPromise(int64_t stream_id, int64_t push_id);
+  bool ReceivePushPromise(
       int64_t stream_id,
       int64_t push_id,
       int32_t token,
       nghttp3_rcbuf* name,
       nghttp3_rcbuf* value,
       uint8_t flags);
-  int H3EndPushPromise(int64_t stream_id, int64_t push_id);
-  void H3CancelPush(int64_t push_id, int64_t stream_id);
-  void H3SendStopSending(int64_t stream_id, uint64_t app_error_code);
-  int H3PushStream(int64_t push_id, int64_t stream_id);
-  int H3EndStream(int64_t stream_id);
+  int EndPushPromise(int64_t stream_id, int64_t push_id);
+  void CancelPush(int64_t push_id, int64_t stream_id);
+  void SendStopSending(int64_t stream_id, uint64_t app_error_code);
+  int PushStream(int64_t push_id, int64_t stream_id);
+  void EndStream(int64_t stream_id);
 
   bool is_control_stream(int64_t stream_id) const {
     return stream_id == control_stream_id_ ||

--- a/src/quic/node_quic_http3_application.h
+++ b/src/quic/node_quic_http3_application.h
@@ -126,9 +126,6 @@ class Http3Application final :
       int64_t stream_id,
       v8::Local<v8::Array> headers) override;
 
-  bool SendPendingData() override;
-  bool SendStreamData(QuicStream* stream) override;
-
   // Implementation for mem::NgLibMemoryManager
   void CheckAllocatedSize(size_t previous_size) const;
   void IncreaseAllocatedSize(size_t size);

--- a/src/quic/node_quic_session-inl.h
+++ b/src/quic/node_quic_session-inl.h
@@ -149,7 +149,7 @@ ssize_t QuicApplication::WriteVStream(
     uint8_t* buf,
     ssize_t* ndatalen,
     const StreamData& stream_data) {
-  CHECK_LE(stream_data.count, 16);
+  CHECK_LE(stream_data.count, MAX_VECTOR_COUNT);
   return ngtcp2_conn_writev_stream(
     session()->connection(),
     &path->path,

--- a/src/quic/node_quic_session-inl.h
+++ b/src/quic/node_quic_session-inl.h
@@ -221,10 +221,10 @@ void QuicSession::ExtendMaxStreamsBidi(uint64_t max_streams) {
 // Extends the stream-level flow control by the given number of bytes.
 void QuicSession::ExtendStreamOffset(QuicStream* stream, size_t amount) {
   Debug(this, "Extending max stream %" PRId64 " offset by %" PRId64 " bytes",
-        stream->GetID(), amount);
+        stream->id(), amount);
   ngtcp2_conn_extend_max_stream_offset(
       connection(),
-      stream->GetID(),
+      stream->id(),
       amount);
 }
 

--- a/src/quic/node_quic_session-inl.h
+++ b/src/quic/node_quic_session-inl.h
@@ -9,7 +9,7 @@
 #include "node_quic_crypto.h"
 #include "node_quic_session.h"
 #include "node_quic_socket.h"
-#include "node_quic_stream.h"
+#include "node_quic_stream-inl.h"
 
 #include <openssl/ssl.h>
 #include <memory>

--- a/src/quic/node_quic_session.cc
+++ b/src/quic/node_quic_session.cc
@@ -1111,7 +1111,7 @@ void QuicApplication::Acknowledge(
 
 bool QuicApplication::SendPendingData() {
   // The maximum number of packets to send per call
-  static constexpr size_t MAX_PACKETS = 16;
+  static constexpr size_t kMaxPackets = 16;
   QuicPathStorage path;
   std::unique_ptr<QuicPacket> packet;
   uint8_t* pos = nullptr;
@@ -1190,7 +1190,7 @@ bool QuicApplication::SendPendingData() {
     packet.reset();
     pos = nullptr;
     MaybeSetFin(stream_data);
-    if (++packets_sent == MAX_PACKETS)
+    if (++packets_sent == kMaxPackets)
       break;
   }
   return true;

--- a/src/quic/node_quic_session.cc
+++ b/src/quic/node_quic_session.cc
@@ -466,7 +466,7 @@ void JSQuicSessionListener::OnStreamReady(BaseObjectPtr<QuicStream> stream) {
   Environment* env = session()->env();
   Local<Value> argv[] = {
     stream->object(),
-    Number::New(env->isolate(), static_cast<double>(stream->GetID()))
+    Number::New(env->isolate(), static_cast<double>(stream->id()))
   };
 
   // Grab a shared pointer to this to prevent the QuicSession
@@ -1423,8 +1423,8 @@ void QuicSession::AddToSocket(QuicSocket* socket) {
 // streams added must be removed before the QuicSession instance is freed.
 void QuicSession::AddStream(BaseObjectPtr<QuicStream> stream) {
   DCHECK(!is_flag_set(QUICSESSION_FLAG_GRACEFUL_CLOSING));
-  Debug(this, "Adding stream %" PRId64 " to session.", stream->GetID());
-  streams_.emplace(stream->GetID(), stream);
+  Debug(this, "Adding stream %" PRId64 " to session.", stream->id());
+  streams_.emplace(stream->id(), stream);
 
   // Update tracking statistics for the number of streams associated with
   // this session.

--- a/src/quic/node_quic_session.h
+++ b/src/quic/node_quic_session.h
@@ -548,8 +548,7 @@ class QuicApplication : public MemoryRetainer {
     int fin = 0;
     ngtcp2_vec data[MAX_VECTOR_COUNT] {};
     ngtcp2_vec* buf = nullptr;
-    void* user_data = nullptr;
-    uint8_t* pos = nullptr;
+    BaseObjectPtr<QuicStream> stream;
     StreamData() { buf = data; }
   };
 

--- a/src/quic/node_quic_session.h
+++ b/src/quic/node_quic_session.h
@@ -22,7 +22,7 @@
 #include <ngtcp2/ngtcp2_crypto.h>
 #include <openssl/ssl.h>
 
-#include <map>
+#include <unordered_map>
 #include <vector>
 
 namespace node {
@@ -34,6 +34,8 @@ class QuicSocket;
 class QuicPacket;
 class QuicStream;
 class QuicHeader;
+
+using StreamsMap = std::unordered_map<int64_t, BaseObjectPtr<QuicStream>>;
 
 enum class QlogMode {
   kDisabled,
@@ -871,9 +873,7 @@ class QuicSession : public AsyncWrap,
   int set_session(SSL_SESSION* session);
   bool set_session(v8::Local<v8::Value> buffer);
 
-  const std::map<int64_t, BaseObjectPtr<QuicStream>>& streams() const {
-    return streams_;
-  }
+  const StreamsMap& streams() const { return streams_; }
 
   // ResetStream will cause ngtcp2 to queue a
   // RESET_STREAM and STOP_SENDING frame, as appropriate,
@@ -1364,7 +1364,7 @@ class QuicSession : public AsyncWrap,
 
   std::unique_ptr<QuicPacket> conn_closebuf_;
 
-  std::map<int64_t, BaseObjectPtr<QuicStream>> streams_;
+  StreamsMap streams_;
 
   AliasedFloat64Array state_;
 

--- a/src/quic/node_quic_session.h
+++ b/src/quic/node_quic_session.h
@@ -555,7 +555,7 @@ class QuicApplication : public MemoryRetainer {
 
   virtual int GetStreamData(StreamData* data) = 0;
   virtual bool StreamCommit(StreamData* data, size_t datalen) = 0;
-  virtual bool ShouldSetFin(StreamData* data) = 0;
+  virtual bool ShouldSetFin(const StreamData& data) = 0;
 
   inline ssize_t WriteVStream(
       QuicPathStorage* path,

--- a/src/quic/node_quic_stream-inl.h
+++ b/src/quic/node_quic_stream-inl.h
@@ -1,0 +1,228 @@
+#ifndef SRC_NODE_QUIC_STREAM_INL_H_
+#define SRC_NODE_QUIC_STREAM_INL_H_
+
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
+#include "node_quic_session.h"
+#include "node_quic_stream.h"
+#include "node_quic_buffer-inl.h"
+
+namespace node {
+namespace quic {
+
+QuicStreamDirection QuicStream::direction() const {
+  return stream_id_ & 0b10 ?
+      QUIC_STREAM_UNIDIRECTIONAL :
+      QUIC_STREAM_BIRECTIONAL;
+}
+
+QuicStreamOrigin QuicStream::origin() const {
+  return stream_id_ & 0b01 ?
+      QUIC_STREAM_SERVER :
+      QUIC_STREAM_CLIENT;
+}
+
+bool QuicStream::is_destroyed() const {
+  return flags_ & QUICSTREAM_FLAG_DESTROYED;
+}
+
+bool QuicStream::has_received_fin() const {
+  return flags_ & QUICSTREAM_FLAG_FIN;
+}
+
+bool QuicStream::has_sent_fin() const {
+  return flags_ & QUICSTREAM_FLAG_FIN_SENT;
+}
+
+bool QuicStream::was_ever_writable() const {
+  if (direction() == QUIC_STREAM_UNIDIRECTIONAL) {
+    return session_->is_server() ?
+        origin() == QUIC_STREAM_SERVER :
+        origin() == QUIC_STREAM_CLIENT;
+  }
+  return true;
+}
+
+bool QuicStream::is_writable() const {
+  if (flags_ & QUICSTREAM_FLAG_WRITE_CLOSED)
+    return false;
+
+  return was_ever_writable();
+}
+
+bool QuicStream::was_ever_readable() const {
+  if (direction() == QUIC_STREAM_UNIDIRECTIONAL) {
+    return session_->is_server() ?
+        origin() == QUIC_STREAM_CLIENT :
+        origin() == QUIC_STREAM_SERVER;
+  }
+
+  return true;
+}
+
+bool QuicStream::is_readable() const {
+  if (flags_ & QUICSTREAM_FLAG_READ_CLOSED)
+    return false;
+
+  return was_ever_readable();
+}
+
+bool QuicStream::is_read_started() const {
+  return flags_ & QUICSTREAM_FLAG_READ_STARTED;
+}
+
+bool QuicStream::is_read_paused() const {
+  return flags_ & QUICSTREAM_FLAG_READ_PAUSED;
+}
+
+bool QuicStream::IsAlive() {
+  return !is_destroyed() && !IsClosing();
+}
+
+bool QuicStream::IsClosing() {
+  return !is_writable() && !is_readable();
+}
+
+void QuicStream::set_fin_sent() {
+  CHECK(!is_writable());
+  flags_ |= QUICSTREAM_FLAG_FIN_SENT;
+}
+
+bool QuicStream::is_write_finished() const {
+  return has_sent_fin() && streambuf_.length() == 0;
+}
+
+void QuicStream::IncrementAvailableOutboundLength(size_t amount) {
+  available_outbound_length_ += amount;
+}
+
+void QuicStream::DecrementAvailableOutboundLength(size_t amount) {
+  available_outbound_length_ -= amount;
+}
+
+void QuicStream::set_fin_received() {
+  flags_ |= QUICSTREAM_FLAG_FIN;
+  set_read_close();
+}
+
+void QuicStream::set_write_close() {
+  flags_ |= QUICSTREAM_FLAG_WRITE_CLOSED;
+}
+
+void QuicStream::set_read_close() {
+  flags_ |= QUICSTREAM_FLAG_READ_CLOSED;
+}
+
+void QuicStream::set_read_start() {
+  flags_ |= QUICSTREAM_FLAG_READ_STARTED;
+}
+
+void QuicStream::set_read_pause() {
+  flags_ |= QUICSTREAM_FLAG_READ_PAUSED;
+}
+
+void QuicStream::set_read_resume() {
+  flags_ &= QUICSTREAM_FLAG_READ_PAUSED;
+}
+
+void QuicStream::set_destroyed() {
+  flags_ |= QUICSTREAM_FLAG_DESTROYED;
+}
+
+bool QuicStream::SubmitInformation(v8::Local<v8::Array> headers) {
+  return session_->SubmitInformation(stream_id_, headers);
+}
+
+bool QuicStream::SubmitHeaders(v8::Local<v8::Array> headers, uint32_t flags) {
+  return session_->SubmitHeaders(stream_id_, headers, flags);
+}
+
+bool QuicStream::SubmitTrailers(v8::Local<v8::Array> headers) {
+  return session_->SubmitTrailers(stream_id_, headers);
+}
+
+void QuicStream::EndHeaders() {
+  Debug(this, "End Headers");
+  // Upon completion of a block of headers, convert the
+  // vector of Header objects into an array of name+value
+  // pairs, then call the on_stream_headers function.
+  session()->application()->StreamHeaders(stream_id_, headers_kind_, headers_);
+  headers_.clear();
+}
+
+void QuicStream::set_headers_kind(QuicStreamHeadersKind kind) {
+  headers_kind_ = kind;
+}
+
+void QuicStream::BeginHeaders(QuicStreamHeadersKind kind) {
+  Debug(this, "Beginning Headers");
+  // Upon start of a new block of headers, ensure that any
+  // previously collected ones are cleaned up.
+  headers_.clear();
+  set_headers_kind(kind);
+}
+
+void QuicStream::Commit(ssize_t amount) {
+  CHECK(!is_destroyed());
+  CHECK_GE(amount, 0);
+  streambuf_.Seek(amount);
+}
+
+int QuicStream::ReadStart() {
+  CHECK(!is_destroyed());
+  CHECK(is_readable());
+  set_read_start();
+  set_read_resume();
+  IncrementStat(
+      inbound_consumed_data_while_paused_,
+      &stream_stats_,
+      &stream_stats::max_offset);
+  session_->ExtendStreamOffset(this, inbound_consumed_data_while_paused_);
+  return 0;
+}
+
+int QuicStream::ReadStop() {
+  CHECK(!is_destroyed());
+  CHECK(is_readable());
+  set_read_pause();
+  return 0;
+}
+
+void QuicStream::ResetStream(uint64_t app_error_code) {
+  // On calling shutdown, the stream will no longer be
+  // readable or writable, all any pending data in the
+  // streambuf_ will be canceled, and all data pending
+  // to be acknowledged at the ngtcp2 level will be
+  // abandoned.
+  set_read_close();
+  set_write_close();
+  session_->ResetStream(stream_id_, app_error_code);
+}
+
+template <typename T>
+size_t QuicStream::DrainInto(
+    std::vector<T>* vec,
+    size_t max_count) {
+  CHECK(!is_destroyed());
+  size_t length = 0;
+  streambuf_.DrainInto(vec, &length, max_count);
+  return length;
+}
+
+template <typename T>
+size_t QuicStream::DrainInto(
+    T* vec,
+    size_t* count,
+    size_t max_count) {
+  CHECK(!is_destroyed());
+  size_t length = 0;
+  streambuf_.DrainInto(vec, count, &length, max_count);
+  return length;
+}
+
+}  // namespace quic
+}  // namespace node
+
+#endif  // NODE_WANT_INTERNALS
+
+#endif  // SRC_NODE_QUIC_STREAM_INL_H_

--- a/src/quic/node_quic_stream-inl.h
+++ b/src/quic/node_quic_stream-inl.h
@@ -220,6 +220,16 @@ size_t QuicStream::DrainInto(
   return length;
 }
 
+void QuicStream::Schedule(Queue* queue) {
+  if (!stream_queue_.IsEmpty())  // Already scheduled?
+    return;
+  queue->PushBack(this);
+}
+
+void QuicStream::Unschedule() {
+  stream_queue_.Remove();
+}
+
 }  // namespace quic
 }  // namespace node
 

--- a/src/quic/node_quic_stream-inl.h
+++ b/src/quic/node_quic_stream-inl.h
@@ -75,14 +75,6 @@ bool QuicStream::is_read_paused() const {
   return flags_ & QUICSTREAM_FLAG_READ_PAUSED;
 }
 
-bool QuicStream::IsAlive() {
-  return !is_destroyed() && !IsClosing();
-}
-
-bool QuicStream::IsClosing() {
-  return !is_writable() && !is_readable();
-}
-
 void QuicStream::set_fin_sent() {
   CHECK(!is_writable());
   flags_ |= QUICSTREAM_FLAG_FIN_SENT;
@@ -166,26 +158,6 @@ void QuicStream::Commit(ssize_t amount) {
   CHECK(!is_destroyed());
   CHECK_GE(amount, 0);
   streambuf_.Seek(amount);
-}
-
-int QuicStream::ReadStart() {
-  CHECK(!is_destroyed());
-  CHECK(is_readable());
-  set_read_start();
-  set_read_resume();
-  IncrementStat(
-      inbound_consumed_data_while_paused_,
-      &stream_stats_,
-      &stream_stats::max_offset);
-  session_->ExtendStreamOffset(this, inbound_consumed_data_while_paused_);
-  return 0;
-}
-
-int QuicStream::ReadStop() {
-  CHECK(!is_destroyed());
-  CHECK(is_readable());
-  set_read_pause();
-  return 0;
 }
 
 void QuicStream::ResetStream(uint64_t app_error_code) {

--- a/src/quic/node_quic_stream.cc
+++ b/src/quic/node_quic_stream.cc
@@ -6,10 +6,9 @@
 #include "node_internals.h"
 #include "stream_base-inl.h"
 #include "node_quic_session-inl.h"
-#include "node_quic_stream.h"
+#include "node_quic_stream-inl.h"
 #include "node_quic_socket.h"
 #include "node_quic_util-inl.h"
-#include "node_sockaddr-inl.h"
 #include "v8.h"
 #include "uv.h"
 
@@ -31,6 +30,15 @@ using v8::String;
 using v8::Value;
 
 namespace quic {
+
+namespace {
+size_t get_length(uv_buf_t* bufs, size_t nbufs) {
+  size_t len = 0;
+  for (size_t n = 0; n < nbufs; n++)
+    len += bufs[n].len;
+  return len;
+}
+}  // namespace
 
 QuicStream::QuicStream(
     QuicSession* sess,
@@ -93,6 +101,52 @@ QuicStream::QuicStream(
       &stream_stats::max_offset);
 }
 
+// Acknowledge is called when ngtcp2 has received an acknowledgement
+// for one or more stream frames for this QuicStream. This will cause
+// data stored in the streambuf_ outbound queue to be consumed and may
+// result in the JavaScript callback for the write to be invoked.
+void QuicStream::Acknowledge(uint64_t offset, size_t datalen) {
+  if (is_destroyed())
+    return;
+
+  // ngtcp2 guarantees that offset must always be greater
+  // than the previously received offset, but let's just
+  // make sure that holds.
+  CHECK_GE(offset, max_offset_ack_);
+  max_offset_ack_ = offset;
+
+  Debug(this, "Acknowledging %d bytes", datalen);
+
+  // Consumes the given number of bytes in the buffer. This may
+  // have the side-effect of causing the onwrite callback to be
+  // invoked if a complete chunk of buffered data has been acknowledged.
+  streambuf_.Consume(datalen);
+
+  uint64_t now = uv_hrtime();
+  if (stream_stats_.stream_acked_at > 0)
+    data_rx_ack_->Record(now - stream_stats_.stream_acked_at);
+  stream_stats_.stream_acked_at = now;
+}
+
+// While not all QUIC applications will support headers, QuicStream
+// includes basic, generic support for storing them.
+bool QuicStream::AddHeader(std::unique_ptr<QuicHeader> header) {
+  Debug(this, "Header Added");
+  size_t len = header->length();
+  QuicApplication* app = session()->application();
+  // We cannot add the header if we've either reached
+  // * the max number of header pairs or
+  // * the max number of header bytes
+  if (headers_.size() == app->max_header_pairs() ||
+      current_headers_length_ + len > app->max_header_length()) {
+    return false;
+  }
+
+  current_headers_length_ += header->length();
+  headers_.emplace_back(std::move(header));
+  return true;
+}
+
 std::string QuicStream::diagnostic_name() const {
   return std::string("QuicStream ") + std::to_string(stream_id_) +
          " (" + std::to_string(static_cast<int64_t>(get_async_id())) +
@@ -139,21 +193,18 @@ void QuicStream::Destroy() {
 int QuicStream::DoShutdown(ShutdownWrap* req_wrap) {
   if (is_destroyed())
     return UV_EPIPE;
-  Debug(this, "Shutdown writable side");
-  // Do nothing if the stream was already shutdown. Specifically,
-  // we should not attempt to send anything on the QuicSession
-  if (!is_writable())
-    return UV_EPIPE;
-  stream_stats_.closing_at = uv_hrtime();
-  set_write_close();
 
-  // If we're not currently within an ngtcp2 callback, then we need to
-  // tell the QuicSession to initiate serialization and sending of any
-  // pending frames.
-  if (!QuicSession::Ngtcp2CallbackScope::InNgtcp2CallbackScope(session_.get()))
-    session_->SendStreamData(this);
+  QuicSession::SendSessionScope send_scope(session());
 
-  return 1;
+  if (is_writable()) {
+    Debug(this, "Shutdown writable side");
+    stream_stats_.closing_at = uv_hrtime();
+    set_write_close();
+    session()->ResumeStream(stream_id_);
+  }
+
+  req_wrap->Done(0);
+  return 0;
 }
 
 int QuicStream::DoWrite(
@@ -170,101 +221,83 @@ int QuicStream::DoWrite(
     return 0;
   }
 
-  BaseObjectPtr<AsyncWrap> strong_ref{req_wrap->GetAsyncWrap()};
-  // The list of buffers will be appended onto streambuf_ without
-  // copying. Those will remain in that buffer until the serialized
-  // stream frames are acknowledged.
-  uint64_t length =
-      streambuf_.Push(
-          bufs,
-          nbufs,
-          [req_wrap, strong_ref](int status) {
-            // This callback function will be invoked once this
-            // complete batch of buffers has been acknowledged
-            // by the peer. This will have the side effect of
-            // blocking additional pending writes from the
-            // javascript side, so writing data to the stream
-            // will be throttled by how quickly the peer is
-            // able to acknowledge stream packets. This is good
-            // in the sense of providing back-pressure, but
-            // also means that writes will be significantly
-            // less performant unless written in batches.
-            req_wrap->Done(status);
-          });
+  // Nothing to write.
+  size_t length = get_length(bufs, nbufs);
+  if (length == 0) {
+    req_wrap->Done(0);
+    return 0;
+  }
+
+  QuicSession::SendSessionScope send_scope(session());
+
   Debug(this, "Queuing %" PRIu64 " bytes of data from %d buffers",
         length, nbufs);
-  IncrementStat(length, &stream_stats_, &stream_stats::bytes_sent);
+  IncrementStat(
+      static_cast<uint64_t>(length),
+      &stream_stats_,
+      &stream_stats::bytes_sent);
+
+  BaseObjectPtr<AsyncWrap> strong_ref{req_wrap->GetAsyncWrap()};
+  // The list of buffers will be appended onto streambuf_ without
+  // copying. Those will remain in the buffer until the serialized
+  // stream frames are acknowledged.
+  // This callback function will be invoked once this
+  // complete batch of buffers has been acknowledged
+  // by the peer. This will have the side effect of
+  // blocking additional pending writes from the
+  // javascript side, so writing data to the stream
+  // will be throttled by how quickly the peer is
+  // able to acknowledge stream packets. This is good
+  // in the sense of providing back-pressure, but
+  // also means that writes will be significantly
+  // less performant unless written in batches.
+  streambuf_.Push(
+      bufs,
+      nbufs,
+      [req_wrap, strong_ref](int status) {
+        req_wrap->Done(status);
+      });
   stream_stats_.stream_sent_at = uv_hrtime();
 
-  // If we're not within an ngtcp2 callback, go ahead and send
-  // the pending stream data. Otherwise, the data will be flushed
-  // once the ngtcp2 callback scope exits and all streams with
-  // data pending are flushed.
-  if (!QuicSession::Ngtcp2CallbackScope::InNgtcp2CallbackScope(session_.get()))
-    session_->SendStreamData(this);
+  session()->ResumeStream(stream_id_);
 
   // IncrementAvailableOutboundLength(len);
   return 0;
 }
 
-// AckedDataOffset is called when ngtcp2 has received an acknowledgement
-// for one or more stream frames for this QuicStream. This will cause
-// data stored in the streambuf_ outbound queue to be consumed and may
-// result in the JavaScript callback for the write to be invoked.
-void QuicStream::AckedDataOffset(uint64_t offset, size_t datalen) {
-  if (is_destroyed())
-    return;
-
-  // ngtcp2 guarantees that offset must always be greater
-  // than the previously received offset, but let's just
-  // make sure that holds.
-  CHECK_GE(offset, max_offset_ack_);
-  max_offset_ack_ = offset;
-
-  Debug(this, "Acknowledging %d bytes", datalen);
-
-  // Consumes the given number of bytes in the buffer. This may
-  // have the side-effect of causing the onwrite callback to be
-  // invoked if a complete chunk of buffered data has been acknowledged.
-  streambuf_.Consume(datalen);
+void QuicStream::IncrementStats(size_t datalen) {
+  uint64_t len = static_cast<uint64_t>(datalen);
+  IncrementStat(len, &stream_stats_, &stream_stats::bytes_received);
 
   uint64_t now = uv_hrtime();
-  if (stream_stats_.stream_acked_at > 0)
-    data_rx_ack_->Record(now - stream_stats_.stream_acked_at);
-  stream_stats_.stream_acked_at = now;
+  if (stream_stats_.stream_received_at > 0)
+    data_rx_rate_->Record(now - stream_stats_.stream_received_at);
+  stream_stats_.stream_received_at = now;
+  data_rx_size_->Record(len);
 }
 
-void QuicStream::Commit(ssize_t amount) {
-  CHECK(!is_destroyed());
-  streambuf_.Seek(amount);
+void QuicStream::MemoryInfo(MemoryTracker* tracker) const {
+  tracker->TrackField("buffer", &streambuf_);
+  tracker->TrackField("data_rx_rate", data_rx_rate_);
+  tracker->TrackField("data_rx_size", data_rx_size_);
+  tracker->TrackField("data_rx_ack", data_rx_ack_);
+  tracker->TrackField("stats_buffer", stats_buffer_);
+  tracker->TrackField("headers", headers_);
 }
 
-inline void QuicStream::IncrementAvailableOutboundLength(size_t amount) {
-  available_outbound_length_ += amount;
-}
-
-inline void QuicStream::DecrementAvailableOutboundLength(size_t amount) {
-  available_outbound_length_ -= amount;
-}
-
-int QuicStream::ReadStart() {
-  CHECK(!is_destroyed());
-  CHECK(is_readable());
-  set_read_start();
-  set_read_resume();
-  IncrementStat(
-      inbound_consumed_data_while_paused_,
-      &stream_stats_,
-      &stream_stats::max_offset);
-  session_->ExtendStreamOffset(this, inbound_consumed_data_while_paused_);
-  return 0;
-}
-
-int QuicStream::ReadStop() {
-  CHECK(!is_destroyed());
-  CHECK(is_readable());
-  set_read_pause();
-  return 0;
+BaseObjectPtr<QuicStream> QuicStream::New(
+    QuicSession* session,
+    int64_t stream_id) {
+  Local<Object> obj;
+  if (!session->env()
+              ->quicserverstream_constructor_template()
+              ->NewInstance(session->env()->context()).ToLocal(&obj)) {
+    return {};
+  }
+  BaseObjectPtr<QuicStream> stream =
+      MakeDetachedBaseObject<QuicStream>(session, obj, stream_id);
+  session->AddStream(stream);
+  return stream;
 }
 
 // Passes chunks of data on to the JavaScript side as soon as they are
@@ -353,100 +386,6 @@ void QuicStream::ReceiveData(
     set_fin_received();
     EmitRead(UV_EOF);
   }
-}
-
-inline void QuicStream::IncrementStats(size_t datalen) {
-  uint64_t len = static_cast<uint64_t>(datalen);
-  IncrementStat(len, &stream_stats_, &stream_stats::bytes_received);
-
-  uint64_t now = uv_hrtime();
-  if (stream_stats_.stream_received_at > 0)
-    data_rx_rate_->Record(now - stream_stats_.stream_received_at);
-  stream_stats_.stream_received_at = now;
-  data_rx_size_->Record(len);
-}
-
-void QuicStream::ResetStream(uint64_t app_error_code) {
-  // On calling shutdown, the stream will no longer be
-  // readable or writable, all any pending data in the
-  // streambuf_ will be canceled, and all data pending
-  // to be acknowledged at the ngtcp2 level will be
-  // abandoned.
-  set_read_close();
-  set_write_close();
-  session_->ResetStream(stream_id_, app_error_code);
-}
-
-BaseObjectPtr<QuicStream> QuicStream::New(
-    QuicSession* session, int64_t stream_id) {
-  Local<Object> obj;
-  if (!session->env()
-              ->quicserverstream_constructor_template()
-              ->NewInstance(session->env()->context()).ToLocal(&obj)) {
-    return {};
-  }
-  BaseObjectPtr<QuicStream> stream =
-      MakeDetachedBaseObject<QuicStream>(session, obj, stream_id);
-  session->AddStream(stream);
-  return stream;
-}
-
-void QuicStream::BeginHeaders(QuicStreamHeadersKind kind) {
-  Debug(this, "Beginning Headers");
-  // Upon start of a new block of headers, ensure that any
-  // previously collected ones are cleaned up.
-  headers_.clear();
-  set_headers_kind(kind);
-}
-
-void QuicStream::set_headers_kind(QuicStreamHeadersKind kind) {
-  headers_kind_ = kind;
-}
-
-bool QuicStream::AddHeader(std::unique_ptr<QuicHeader> header) {
-  Debug(this, "Header Added");
-  size_t len = header->length();
-  QuicApplication* app = session()->application();
-  // We cannot add the header if we've either reached
-  // * the max number of header pairs or
-  // * the max number of header bytes
-  if (headers_.size() == app->max_header_pairs() ||
-      current_headers_length_ + len > app->max_header_length()) {
-    return false;
-  }
-
-  current_headers_length_ += header->length();
-  headers_.emplace_back(std::move(header));
-  return true;
-}
-
-void QuicStream::EndHeaders() {
-  Debug(this, "End Headers");
-  // Upon completion of a block of headers, convert the
-  // vector of Header objects into an array of name+value
-  // pairs, then call the on_stream_headers function.
-  session()->application()->StreamHeaders(stream_id_, headers_kind_, headers_);
-  headers_.clear();
-}
-
-void QuicStream::MemoryInfo(MemoryTracker* tracker) const {
-  tracker->TrackField("buffer", &streambuf_);
-  tracker->TrackField("data_rx_rate", data_rx_rate_);
-  tracker->TrackField("data_rx_size", data_rx_size_);
-  tracker->TrackField("data_rx_ack", data_rx_ack_);
-  tracker->TrackField("stats_buffer", stats_buffer_);
-}
-
-bool QuicStream::SubmitInformation(v8::Local<v8::Array> headers) {
-  return session_->SubmitInformation(stream_id_, headers);
-}
-
-bool QuicStream::SubmitHeaders(v8::Local<v8::Array> headers, uint32_t flags) {
-  return session_->SubmitHeaders(stream_id_, headers, flags);
-}
-
-bool QuicStream::SubmitTrailers(v8::Local<v8::Array> headers) {
-  return session_->SubmitTrailers(stream_id_, headers);
 }
 
 // JavaScript API

--- a/src/quic/node_quic_stream.cc
+++ b/src/quic/node_quic_stream.cc
@@ -94,7 +94,7 @@ QuicStream::QuicStream(
 }
 
 std::string QuicStream::diagnostic_name() const {
-  return std::string("QuicStream ") + std::to_string(GetID()) +
+  return std::string("QuicStream ") + std::to_string(stream_id_) +
          " (" + std::to_string(static_cast<int64_t>(get_async_id())) +
          ", " + session_->diagnostic_name() + ")";
 }
@@ -374,7 +374,7 @@ void QuicStream::ResetStream(uint64_t app_error_code) {
   // abandoned.
   set_read_close();
   set_write_close();
-  session_->ResetStream(GetID(), app_error_code);
+  session_->ResetStream(stream_id_, app_error_code);
 }
 
 BaseObjectPtr<QuicStream> QuicStream::New(
@@ -425,7 +425,7 @@ void QuicStream::EndHeaders() {
   // Upon completion of a block of headers, convert the
   // vector of Header objects into an array of name+value
   // pairs, then call the on_stream_headers function.
-  session()->application()->StreamHeaders(GetID(), headers_kind_, headers_);
+  session()->application()->StreamHeaders(stream_id_, headers_kind_, headers_);
   headers_.clear();
 }
 
@@ -438,15 +438,15 @@ void QuicStream::MemoryInfo(MemoryTracker* tracker) const {
 }
 
 bool QuicStream::SubmitInformation(v8::Local<v8::Array> headers) {
-  return session_->SubmitInformation(GetID(), headers);
+  return session_->SubmitInformation(stream_id_, headers);
 }
 
 bool QuicStream::SubmitHeaders(v8::Local<v8::Array> headers, uint32_t flags) {
-  return session_->SubmitHeaders(GetID(), headers, flags);
+  return session_->SubmitHeaders(stream_id_, headers, flags);
 }
 
 bool QuicStream::SubmitTrailers(v8::Local<v8::Array> headers) {
-  return session_->SubmitTrailers(GetID(), headers);
+  return session_->SubmitTrailers(stream_id_, headers);
 }
 
 // JavaScript API
@@ -454,7 +454,7 @@ namespace {
 void QuicStreamGetID(const FunctionCallbackInfo<Value>& args) {
   QuicStream* stream;
   ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
-  args.GetReturnValue().Set(static_cast<double>(stream->GetID()));
+  args.GetReturnValue().Set(static_cast<double>(stream->id()));
 }
 
 void OpenUnidirectionalStream(const FunctionCallbackInfo<Value>& args) {

--- a/src/quic/node_quic_stream.h
+++ b/src/quic/node_quic_stream.h
@@ -341,10 +341,10 @@ class QuicStream : public AsyncWrap, public StreamBase {
   inline bool SubmitTrailers(v8::Local<v8::Array> headers);
 
   // Required for StreamBase
-  inline bool IsAlive() override;
-  inline bool IsClosing() override;
-  inline int ReadStart() override;
-  inline int ReadStop() override;
+  bool IsAlive() override;
+  bool IsClosing() override;
+  int ReadStart() override;
+  int ReadStop() override;
   int DoShutdown(ShutdownWrap* req_wrap) override;
 
   AsyncWrap* GetAsyncWrap() override { return this; }

--- a/src/quic/node_quic_stream.h
+++ b/src/quic/node_quic_stream.h
@@ -209,7 +209,7 @@ class QuicStream : public AsyncWrap, public StreamBase {
         QUIC_STREAM_CLIENT;
   }
 
-  int64_t GetID() const { return stream_id_; }
+  int64_t id() const { return stream_id_; }
 
   inline bool is_destroyed() const {
     return flags_ & QUICSTREAM_FLAG_DESTROYED;

--- a/src/quic/node_quic_stream.h
+++ b/src/quic/node_quic_stream.h
@@ -9,6 +9,7 @@
 #include "histogram-inl.h"
 #include "node_quic_util.h"
 #include "stream_base-inl.h"
+#include "util-inl.h"
 #include "v8.h"
 
 #include <string>
@@ -18,6 +19,7 @@ namespace node {
 namespace quic {
 
 class QuicSession;
+class QuicApplication;
 
 enum QuicStreamHeaderFlags : uint32_t {
   // No flags
@@ -420,6 +422,14 @@ class QuicStream : public AsyncWrap, public StreamBase {
   BaseObjectPtr<HistogramBase> data_rx_ack_;
 
   AliasedBigUint64Array stats_buffer_;
+
+  ListNode<QuicStream> stream_queue_;
+
+ public:
+  // Linked List of QuicStream objects
+  using Queue = ListHead<QuicStream, &QuicStream::stream_queue_>;
+  inline void Schedule(Queue* queue);
+  inline void Unschedule();
 };
 
 }  // namespace quic

--- a/src/quic/node_quic_stream.h
+++ b/src/quic/node_quic_stream.h
@@ -54,7 +54,7 @@ enum QuicStreamStatsIdx : int {
 // different internal representations for a header name+value
 // pair. QuicApplication implementations that support headers
 // per stream must create a specialization of the Header class.
-class QuicHeader {
+class QuicHeader : public MemoryRetainer {
  public:
   QuicHeader() {}
 
@@ -67,6 +67,55 @@ class QuicHeader {
   // Returns the total length of the header in bytes
   // (including the name and value)
   virtual size_t length() const = 0;
+};
+
+enum QuicStreamStates : uint32_t {
+  // QuicStream is fully open. Readable and Writable
+  QUICSTREAM_FLAG_INITIAL = 0x0,
+
+  // QuicStream Read State is closed because a final stream frame
+  // has been received from the peer or the QuicStream is unidirectional
+  // outbound only (i.e. it was never readable)
+  QUICSTREAM_FLAG_READ_CLOSED = 0x1,
+
+  // QuicStream Write State is closed. There may still be data
+  // in the outbound queue waiting to be serialized or acknowledged.
+  // No additional data may be added to the queue, however, and a
+  // final stream packet will be sent once all of the data in the
+  // queue has been serialized.
+  QUICSTREAM_FLAG_WRITE_CLOSED = 0x2,
+
+  // JavaScript side has switched into flowing mode (Readable side)
+  QUICSTREAM_FLAG_READ_STARTED = 0x4,
+
+  // JavaScript side has paused the flow of data (Readable side)
+  QUICSTREAM_FLAG_READ_PAUSED = 0x8,
+
+  // QuicStream has received a final stream frame (Readable side)
+  QUICSTREAM_FLAG_FIN = 0x10,
+
+  // QuicStream has sent a final stream frame (Writable side)
+  QUICSTREAM_FLAG_FIN_SENT = 0x20,
+
+  // QuicStream has been destroyed
+  QUICSTREAM_FLAG_DESTROYED = 0x40
+};
+
+enum QuicStreamDirection {
+  // The QuicStream is readable and writable in both directions
+  QUIC_STREAM_BIRECTIONAL,
+
+  // The QuicStream is writable and readable in only one direction.
+  // The direction depends on the QuicStreamOrigin.
+  QUIC_STREAM_UNIDIRECTIONAL
+};
+
+enum QuicStreamOrigin {
+  // The QuicStream was created by the server.
+  QUIC_STREAM_SERVER,
+
+  // The QuicStream was created by the client.
+  QUIC_STREAM_CLIENT
 };
 
 // QuicStream's are simple data flows that, fortunately, do not
@@ -137,183 +186,96 @@ class QuicHeader {
 // ngtcp2 level.
 class QuicStream : public AsyncWrap, public StreamBase {
  public:
-  enum QuicStreamStates : uint32_t {
-    // QuicStream is fully open. Readable and Writable
-    QUICSTREAM_FLAG_INITIAL = 0x0,
-
-    // QuicStream Read State is closed because a final stream frame
-    // has been received from the peer or the QuicStream is unidirectional
-    // outbound only (i.e. it was never readable)
-    QUICSTREAM_FLAG_READ_CLOSED = 0x1,
-
-    // QuicStream Write State is closed. There may still be data
-    // in the outbound queue waiting to be serialized or acknowledged.
-    // No additional data may be added to the queue, however, and a
-    // final stream packet will be sent once all of the data in the
-    // queue has been serialized.
-    QUICSTREAM_FLAG_WRITE_CLOSED = 0x2,
-
-    // JavaScript side has switched into flowing mode (Readable side)
-    QUICSTREAM_FLAG_READ_STARTED = 0x4,
-
-    // JavaScript side has paused the flow of data (Readable side)
-    QUICSTREAM_FLAG_READ_PAUSED = 0x8,
-
-    // QuicStream has received a final stream frame (Readable side)
-    QUICSTREAM_FLAG_FIN = 0x10,
-
-    // QuicStream has sent a final stream frame (Writable side)
-    QUICSTREAM_FLAG_FIN_SENT = 0x20,
-
-    // QuicStream has been destroyed
-    QUICSTREAM_FLAG_DESTROYED = 0x40
-  };
-
-  enum QuicStreamDirection {
-    // The QuicStream is readable and writable in both directions
-    QUIC_STREAM_BIRECTIONAL,
-
-    // The QuicStream is writable and readable in only one direction.
-    // The direction depends on the QuicStreamOrigin.
-    QUIC_STREAM_UNIDIRECTIONAL
-  };
-
-  enum QuicStreamOrigin {
-    // The QuicStream was created by the server.
-    QUIC_STREAM_SERVER,
-
-    // The QuicStream was created by the client.
-    QUIC_STREAM_CLIENT
-  };
-
-
   static void Initialize(
       Environment* env,
       v8::Local<v8::Object> target,
       v8::Local<v8::Context> context);
 
   static BaseObjectPtr<QuicStream> New(
-      QuicSession* session, int64_t stream_id);
+      QuicSession* session,
+      int64_t stream_id);
+
+  QuicStream(
+      QuicSession* session,
+      v8::Local<v8::Object> target,
+      int64_t stream_id);
 
   std::string diagnostic_name() const override;
 
-  inline QuicStreamDirection direction() const {
-    return stream_id_ & 0b10 ?
-        QUIC_STREAM_UNIDIRECTIONAL :
-        QUIC_STREAM_BIRECTIONAL;
-  }
-
-  inline QuicStreamOrigin origin() const {
-    return stream_id_ & 0b01 ?
-        QUIC_STREAM_SERVER :
-        QUIC_STREAM_CLIENT;
-  }
-
   int64_t id() const { return stream_id_; }
+  QuicSession* session() const { return session_.get(); }
 
-  inline bool is_destroyed() const {
-    return flags_ & QUICSTREAM_FLAG_DESTROYED;
-  }
+  // A QuicStream can be either uni- or bi-directional.
+  inline QuicStreamDirection direction() const;
+
+  // A QuicStream can be initiated by either the client
+  // or the server.
+  inline QuicStreamOrigin origin() const;
+
+  // The QuicStream has been destroyed and is no longer usable.
+  inline bool is_destroyed() const;
 
   // The QUICSTREAM_FLAG_FIN flag will be set only when a final stream
   // frame has been received from the peer.
-  inline bool has_received_fin() const {
-    return flags_ & QUICSTREAM_FLAG_FIN;
-  }
+  inline bool has_received_fin() const;
 
   // The QUICSTREAM_FLAG_FIN_SENT flag will be set only when a final
   // stream frame has been transmitted to the peer. Once sent, no
   // additional data may be transmitted to the peer. If has_sent_fin()
   // is set, is_writable() can be assumed to be false.
-  inline bool has_sent_fin() const {
-    return flags_ & QUICSTREAM_FLAG_FIN_SENT;
-  }
+  inline bool has_sent_fin() const;
 
   // WasEverWritable returns true if it is a bidirectional stream,
   // or a Unidirectional stream originating from the local peer.
   // If was_ever_writable() is false, then no stream frames should
   // ever be sent from the local peer, including final stream frames.
-  inline bool was_ever_writable() const {
-    if (direction() == QUIC_STREAM_UNIDIRECTIONAL) {
-      return session_->is_server() ?
-          origin() == QUIC_STREAM_SERVER :
-          origin() == QUIC_STREAM_CLIENT;
-    }
-    return true;
-  }
+  inline bool was_ever_writable() const;
 
   // A QuicStream will not be writable if:
   //  - The QUICSTREAM_FLAG_WRITE_CLOSED flag is set or
   //  - It is a Unidirectional stream originating from the peer
-  inline bool is_writable() const {
-    if (flags_ & QUICSTREAM_FLAG_WRITE_CLOSED)
-      return false;
-
-    return was_ever_writable();
-  }
+  inline bool is_writable() const;
 
   // WasEverReadable returns true if it is a bidirectional stream,
   // or a Unidirectional stream originating from the remote
   // peer.
-  inline bool was_ever_readable() const {
-    if (direction() == QUIC_STREAM_UNIDIRECTIONAL) {
-      return session_->is_server() ?
-          origin() == QUIC_STREAM_CLIENT :
-          origin() == QUIC_STREAM_SERVER;
-    }
-
-    return true;
-  }
+  inline bool was_ever_readable() const;
 
   // A QuicStream will not be readable if:
   //  - The QUICSTREAM_FLAG_READ_CLOSED flag is set or
   //  - It is a Unidirectional stream originating from the local peer.
-  inline bool is_readable() const {
-    if (flags_ & QUICSTREAM_FLAG_READ_CLOSED)
-      return false;
+  inline bool is_readable() const;
 
-    return was_ever_readable();
-  }
+  // True if reading from this QuicStream has ever initiated.
+  inline bool is_read_started() const;
 
-  inline bool is_read_started() const {
-    return flags_ & QUICSTREAM_FLAG_READ_STARTED;
-  }
-
-  inline bool is_read_paused() const {
-    return flags_ & QUICSTREAM_FLAG_READ_PAUSED;
-  }
-
-  bool IsAlive() override {
-    return !is_destroyed() && !IsClosing();
-  }
-
-  bool IsClosing() override {
-    return !is_writable() && !is_readable();
-  }
+  // True if reading from this QuicStream is currently paused.
+  inline bool is_read_paused() const;
 
   // Records the fact that a final stream frame has been
   // serialized and sent to the peer. There still may be
   // unacknowledged data in the outbound queue, but no
   // additional frames may be sent for the stream other
   // than reset stream.
-  inline void set_fin_sent() {
-    CHECK(!is_writable());
-    flags_ |= QUICSTREAM_FLAG_FIN_SENT;
-  }
+  inline void set_fin_sent();
 
   // IsWriteFinished will return true if a final stream frame
   // has been sent and all data has been acknowledged (the
   // send buffer is empty).
-  inline bool is_write_finished() {
-    return has_sent_fin() && streambuf_.length() == 0;
-  }
+  inline bool is_write_finished() const;
 
-  QuicSession* session() const { return session_.get(); }
+  // Specifies the kind of headers currently being processed.
+  inline void set_headers_kind(QuicStreamHeadersKind kind);
 
-  virtual void AckedDataOffset(uint64_t offset, size_t datalen);
+  // Marks the given data range as having been acknowledged.
+  // This means that the data range may be released from
+  // memory.
+  void Acknowledge(uint64_t offset, size_t datalen);
 
-  virtual void Destroy();
+  // Destroy the QuicStream and render it no longer usable.
+  void Destroy();
 
+  // Buffers chunks of data to be written to the QUIC connection.
   int DoWrite(
       WriteWrap* req_wrap,
       uv_buf_t* bufs,
@@ -323,118 +285,83 @@ class QuicStream : public AsyncWrap, public StreamBase {
   inline void IncrementAvailableOutboundLength(size_t amount);
   inline void DecrementAvailableOutboundLength(size_t amount);
 
-  virtual void ReceiveData(
-      int fin,
-      const uint8_t* data,
-      size_t datalen,
-      uint64_t offset);
-
-  bool SubmitInformation(v8::Local<v8::Array> headers);
-  bool SubmitHeaders(v8::Local<v8::Array> headers, uint32_t flags);
-  bool SubmitTrailers(v8::Local<v8::Array> headers);
-
-  // Required for StreamBase
-  int ReadStart() override;
-
-  // Required for StreamBase
-  int ReadStop() override;
-
-  // Required for StreamBase
-  int DoShutdown(ShutdownWrap* req_wrap) override;
-
-  void ResetStream(uint64_t app_error_code);
-
-  void Commit(ssize_t amount);
-
-  template <typename T>
-  inline size_t DrainInto(
-      std::vector<T>* vec,
-      size_t max_count = MAX_VECTOR_COUNT) {
-    CHECK(!is_destroyed());
-    size_t length = 0;
-    streambuf_.DrainInto(vec, &length, max_count);
-    return length;
-  }
-
-  template <typename T>
-  inline size_t DrainInto(
-      T* vec,
-      size_t* count,
-      size_t max_count = MAX_VECTOR_COUNT) {
-    CHECK(!is_destroyed());
-    size_t length = 0;
-    streambuf_.DrainInto(vec, count, &length, max_count);
-    return length;
-  }
-
-  AsyncWrap* GetAsyncWrap() override { return this; }
+  // Returns false if the header cannot be added. This will
+  // typically only happen if a maximimum number of headers
+  // has been reached.
+  bool AddHeader(std::unique_ptr<QuicHeader> header);
 
   // Some QUIC applications support headers, others do not.
   // The following methods allow consistent handling of
   // headers at the QuicStream level regardless of the
   // protocol. For applications that do not support headers,
   // these are simply not used.
-  void BeginHeaders(QuicStreamHeadersKind kind = QUICSTREAM_HEADERS_KIND_NONE);
+  inline void BeginHeaders(
+      QuicStreamHeadersKind kind = QUICSTREAM_HEADERS_KIND_NONE);
 
-  // Returns false if the header cannot be added. This will
-  // typically only happen if a maximimum number of headers
-  // has been reached.
-  bool AddHeader(std::unique_ptr<QuicHeader> header);
-  void EndHeaders();
+  // Indicates an amount of unacknowledged data that has been
+  // submitted to the QUIC connection.
+  inline void Commit(ssize_t amount);
 
-  // Sets the kind of headers currently being processed.
-  void set_headers_kind(QuicStreamHeadersKind kind);
+  template <typename T>
+  inline size_t DrainInto(
+      std::vector<T>* vec,
+      size_t max_count = MAX_VECTOR_COUNT);
 
+  template <typename T>
+  inline size_t DrainInto(
+      T* vec,
+      size_t* count,
+      size_t max_count = MAX_VECTOR_COUNT);
+
+  inline void EndHeaders();
+
+  // Passes a chunk of data on to the QuicStream listener.
+  void ReceiveData(
+      int fin,
+      const uint8_t* data,
+      size_t datalen,
+      uint64_t offset);
+
+  // Resets the QUIC stream, sending a signal to the peer that
+  // no additional data will be transmitted for this stream.
+  inline void ResetStream(uint64_t app_error_code = 0);
+
+  // Submits informational headers. Returns false if headers are not
+  // supported on the underlying QuicApplication.
+  inline bool SubmitInformation(v8::Local<v8::Array> headers);
+
+  // Submits initial headers. Returns false if headers are not
+  // supported on the underlying QuicApplication.
+  inline bool SubmitHeaders(v8::Local<v8::Array> headers, uint32_t flags);
+
+  // Submits trailing headers. Returns false if headers are not
+  // supported on the underlying QuicApplication.
+  inline bool SubmitTrailers(v8::Local<v8::Array> headers);
+
+  // Required for StreamBase
+  inline bool IsAlive() override;
+  inline bool IsClosing() override;
+  inline int ReadStart() override;
+  inline int ReadStop() override;
+  int DoShutdown(ShutdownWrap* req_wrap) override;
+
+  AsyncWrap* GetAsyncWrap() override { return this; }
+
+  // Required for MemoryRetainer
   void MemoryInfo(MemoryTracker* tracker) const override;
-
   SET_MEMORY_INFO_NAME(QuicStream)
   SET_SELF_SIZE(QuicStream)
 
-  QuicStream(
-      QuicSession* session,
-      v8::Local<v8::Object> target,
-      int64_t stream_id);
-
  private:
-  // Called only when a final stream frame has been received from
-  // the peer. This has the side effect of marking the readable
-  // side of the stream closed. No additional data will be received
-  // on this QuicStream.
-  inline void set_fin_received() {
-    flags_ |= QUICSTREAM_FLAG_FIN;
-    set_read_close();
-  }
+  inline void set_fin_received();
+  inline void set_write_close();
+  inline void set_read_close();
+  inline void set_read_start();
+  inline void set_read_pause();
+  inline void set_read_resume();
+  inline void set_destroyed();
 
-  // SetWriteClose is called either when the QuicStream is created
-  // and is unidirectional from the peer, or when DoShutdown is called.
-  // This will indicate that the writable side of the QuicStream is
-  // closed and that no data will be pushed to the outbound queue.
-  inline void set_write_close() {
-    flags_ |= QUICSTREAM_FLAG_WRITE_CLOSED;
-  }
-
-  // Called when no additional data can be received on the QuicStream.
-  inline void set_read_close() {
-    flags_ |= QUICSTREAM_FLAG_READ_CLOSED;
-  }
-
-  inline void set_read_start() {
-    flags_ |= QUICSTREAM_FLAG_READ_STARTED;
-  }
-
-  inline void set_read_pause() {
-    flags_ |= QUICSTREAM_FLAG_READ_PAUSED;
-  }
-
-  inline void set_read_resume() {
-    flags_ &= QUICSTREAM_FLAG_READ_PAUSED;
-  }
-
-  inline void set_destroyed() {
-    flags_ |= QUICSTREAM_FLAG_DESTROYED;
-  }
-
-  inline void IncrementStats(size_t datalen);
+  void IncrementStats(size_t datalen);
 
   BaseObjectWeakPtr<QuicSession> session_;
   int64_t stream_id_;


### PR DESCRIPTION
This is a multi-step cleanup of `QuicApplication::SendPendingData`, allowing both `DefaultApplication` and `Http3Application` to use the same base `SendPendingData()` logic and making the iteration over `QuicStream` instances in `DefaultApplication` more efficient by only iterating over those that have data to send.