### PR TITLE
quic: refactor stats tracking

### DIFF
--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -137,6 +137,9 @@ const {
     IDX_QUIC_SESSION_STATS_ACK_DELAY_RETRANSMIT_COUNT,
     IDX_QUIC_SESSION_STATS_MAX_BYTES_IN_FLIGHT,
     IDX_QUIC_SESSION_STATS_BLOCK_COUNT,
+    IDX_QUIC_SESSION_STATS_MIN_RTT,
+    IDX_QUIC_SESSION_STATS_SMOOTHED_RTT,
+    IDX_QUIC_SESSION_STATS_LATEST_RTT,
     IDX_QUIC_STREAM_STATS_CREATED_AT,
     IDX_QUIC_STREAM_STATS_BYTES_RECEIVED,
     IDX_QUIC_STREAM_STATS_BYTES_SENT,
@@ -1492,7 +1495,6 @@ class QuicSession extends EventEmitter {
   #destroyed = false;
   #handshakeComplete = false;
   #maxPacketLength = IDX_QUIC_SESSION_MAX_PACKET_SIZE_DEFAULT;
-  #recoveryStats = undefined;
   #servername = undefined;
   #socket = undefined;
   #statelessReset = false;
@@ -1746,9 +1748,8 @@ class QuicSession extends EventEmitter {
 
     const handle = this[kHandle];
     if (handle !== undefined) {
-      // Copy the stats and recoveryStats for use after destruction
+      // Copy the stats for use after destruction
       this.#stats = new BigInt64Array(handle.stats);
-      this.#recoveryStats = new Float64Array(handle.recoveryStats);
       // Calling destroy will cause a CONNECTION_CLOSE to be
       // sent to the peer and will destroy the QuicSession
       // handler immediately.
@@ -1981,18 +1982,18 @@ class QuicSession extends EventEmitter {
   }
 
   get minRTT() {
-    const stats = this.#recoveryStats || this[kHandle].recoveryStats;
-    return stats[0];
+    const stats = this.#stats || this[kHandle].stats;
+    return stats[IDX_QUIC_SESSION_STATS_MIN_RTT];
   }
 
   get latestRTT() {
-    const stats = this.#recoveryStats || this[kHandle].recoveryStats;
-    return stats[1];
+    const stats = this.#stats || this[kHandle].stats;
+    return stats[IDX_QUIC_SESSION_STATS_LATEST_RTT];
   }
 
   get smoothedRTT() {
-    const stats = this.#recoveryStats || this[kHandle].recoveryStats;
-    return stats[2];
+    const stats = this.#stats || this[kHandle].stats;
+    return stats[IDX_QUIC_SESSION_STATS_SMOOTHED_RTT];
   }
 
   updateKey() {

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -1519,10 +1519,8 @@ class QuicSession extends EventEmitter {
     this[kHandle] = handle;
     if (handle !== undefined) {
       handle[owner_symbol] = this;
-      this.#handshakeAckHistogram =
-        new Histogram(handle.crypto_rx_ack);
-      this.#handshakeContinuationHistogram =
-        new Histogram(handle.crypto_handshake_rate);
+      this.#handshakeAckHistogram = new Histogram(handle.ack);
+      this.#handshakeContinuationHistogram = new Histogram(handle.rate);
     } else {
       if (this.#handshakeAckHistogram)
         this.#handshakeAckHistogram[kDestroyHistogram]();
@@ -2353,9 +2351,9 @@ class QuicStream extends Duplex {
       this[async_id_symbol] = handle.getAsyncId();
       this.#id = handle.id();
 
-      this.#dataRateHistogram = new Histogram(handle.data_rx_rate);
-      this.#dataSizeHistogram = new Histogram(handle.data_rx_size);
-      this.#dataAckHistogram = new Histogram(handle.data_rx_ack);
+      this.#dataRateHistogram = new Histogram(handle.rate);
+      this.#dataSizeHistogram = new Histogram(handle.size);
+      this.#dataAckHistogram = new Histogram(handle.ack);
 
       this.emit('ready');
     } else {

--- a/src/env.h
+++ b/src/env.h
@@ -172,6 +172,7 @@ constexpr size_t kFsStatsBufferLength =
 // Strings are per-isolate primitives but Environment proxies them
 // for the sake of convenience.  Strings should be ASCII-only.
 #define PER_ISOLATE_STRING_PROPERTIES(V)                                       \
+  V(ack_string, "ack")                                                         \
   V(address_string, "address")                                                 \
   V(aliases_string, "aliases")                                                 \
   V(args_string, "args")                                                       \
@@ -198,16 +199,11 @@ constexpr size_t kFsStatsBufferLength =
   V(crypto_ec_string, "ec")                                                    \
   V(crypto_ed25519_string, "ed25519")                                          \
   V(crypto_ed448_string, "ed448")                                              \
-  V(crypto_handshake_rate_string, "crypto_handshake_rate")                     \
   V(crypto_x25519_string, "x25519")                                            \
   V(crypto_x448_string, "x448")                                                \
   V(crypto_rsa_string, "rsa")                                                  \
   V(crypto_rsa_pss_string, "rsa-pss")                                          \
-  V(crypto_rx_ack_string, "crypto_rx_ack")                                     \
   V(cwd_string, "cwd")                                                         \
-  V(data_rx_ack_string, "data_rx_ack")                                         \
-  V(data_rx_rate_string, "data_rx_rate")                                       \
-  V(data_rx_size_string, "data_rx_size")                                       \
   V(data_string, "data")                                                       \
   V(default_string, "default")                                                 \
   V(dest_string, "dest")                                                       \
@@ -335,6 +331,7 @@ constexpr size_t kFsStatsBufferLength =
   V(pubkey_string, "pubkey")                                                   \
   V(query_string, "query")                                                     \
   V(quic_alpn_string, "h3-24")                                                 \
+  V(rate_string, "rate")                                                       \
   V(raw_string, "raw")                                                         \
   V(read_host_object_string, "_readHostObject")                                \
   V(readable_string, "readable")                                               \

--- a/src/env.h
+++ b/src/env.h
@@ -339,7 +339,6 @@ constexpr size_t kFsStatsBufferLength =
   V(read_host_object_string, "_readHostObject")                                \
   V(readable_string, "readable")                                               \
   V(reason_string, "reason")                                                   \
-  V(recovery_stats_string, "recoveryStats")                                    \
   V(refresh_string, "refresh")                                                 \
   V(regexp_string, "regexp")                                                   \
   V(rename_string, "rename")                                                   \

--- a/src/quic/node_quic.cc
+++ b/src/quic/node_quic.cc
@@ -162,29 +162,6 @@ void Initialize(Local<Object> target,
   V(IDX_QUIC_SESSION_DISABLE_MIGRATION)                                        \
   V(IDX_QUIC_SESSION_MAX_ACK_DELAY)                                            \
   V(IDX_QUIC_SESSION_CONFIG_COUNT)                                             \
-  V(IDX_QUIC_SESSION_STATS_CREATED_AT)                                         \
-  V(IDX_QUIC_SESSION_STATS_HANDSHAKE_START_AT)                                 \
-  V(IDX_QUIC_SESSION_STATS_HANDSHAKE_SEND_AT)                                  \
-  V(IDX_QUIC_SESSION_STATS_HANDSHAKE_CONTINUE_AT)                              \
-  V(IDX_QUIC_SESSION_STATS_HANDSHAKE_COMPLETED_AT)                             \
-  V(IDX_QUIC_SESSION_STATS_HANDSHAKE_ACKED_AT)                                 \
-  V(IDX_QUIC_SESSION_STATS_SENT_AT)                                            \
-  V(IDX_QUIC_SESSION_STATS_RECEIVED_AT)                                        \
-  V(IDX_QUIC_SESSION_STATS_CLOSING_AT)                                         \
-  V(IDX_QUIC_SESSION_STATS_BYTES_RECEIVED)                                     \
-  V(IDX_QUIC_SESSION_STATS_BYTES_SENT)                                         \
-  V(IDX_QUIC_SESSION_STATS_BIDI_STREAM_COUNT)                                  \
-  V(IDX_QUIC_SESSION_STATS_UNI_STREAM_COUNT)                                   \
-  V(IDX_QUIC_SESSION_STATS_STREAMS_IN_COUNT)                                   \
-  V(IDX_QUIC_SESSION_STATS_STREAMS_OUT_COUNT)                                  \
-  V(IDX_QUIC_SESSION_STATS_KEYUPDATE_COUNT)                                    \
-  V(IDX_QUIC_SESSION_STATS_RETRY_COUNT)                                        \
-  V(IDX_QUIC_SESSION_STATS_LOSS_RETRANSMIT_COUNT)                              \
-  V(IDX_QUIC_SESSION_STATS_ACK_DELAY_RETRANSMIT_COUNT)                         \
-  V(IDX_QUIC_SESSION_STATS_PATH_VALIDATION_SUCCESS_COUNT)                      \
-  V(IDX_QUIC_SESSION_STATS_PATH_VALIDATION_FAILURE_COUNT)                      \
-  V(IDX_QUIC_SESSION_STATS_MAX_BYTES_IN_FLIGHT)                                \
-  V(IDX_QUIC_SESSION_STATS_BLOCK_COUNT)                                        \
   V(IDX_QUIC_SESSION_STATE_CERT_ENABLED)                                       \
   V(IDX_QUIC_SESSION_STATE_CLIENT_HELLO_ENABLED)                               \
   V(IDX_QUIC_SESSION_STATE_USE_PREFERRED_ADDRESS_ENABLED)                      \
@@ -194,25 +171,6 @@ void Initialize(Local<Object> target,
   V(IDX_QUIC_SESSION_STATE_MAX_STREAMS_UNI)                                    \
   V(IDX_QUIC_SESSION_STATE_MAX_DATA_LEFT)                                      \
   V(IDX_QUIC_SESSION_STATE_BYTES_IN_FLIGHT)                                    \
-  V(IDX_QUIC_SOCKET_STATS_CREATED_AT)                                          \
-  V(IDX_QUIC_SOCKET_STATS_BOUND_AT)                                            \
-  V(IDX_QUIC_SOCKET_STATS_LISTEN_AT)                                           \
-  V(IDX_QUIC_SOCKET_STATS_BYTES_RECEIVED)                                      \
-  V(IDX_QUIC_SOCKET_STATS_BYTES_SENT)                                          \
-  V(IDX_QUIC_SOCKET_STATS_PACKETS_RECEIVED)                                    \
-  V(IDX_QUIC_SOCKET_STATS_PACKETS_IGNORED)                                     \
-  V(IDX_QUIC_SOCKET_STATS_PACKETS_SENT)                                        \
-  V(IDX_QUIC_SOCKET_STATS_SERVER_SESSIONS)                                     \
-  V(IDX_QUIC_SOCKET_STATS_CLIENT_SESSIONS)                                     \
-  V(IDX_QUIC_SOCKET_STATS_STATELESS_RESET_COUNT)                               \
-  V(IDX_QUIC_STREAM_STATS_CREATED_AT)                                          \
-  V(IDX_QUIC_STREAM_STATS_SENT_AT)                                             \
-  V(IDX_QUIC_STREAM_STATS_RECEIVED_AT)                                         \
-  V(IDX_QUIC_STREAM_STATS_ACKED_AT)                                            \
-  V(IDX_QUIC_STREAM_STATS_CLOSING_AT)                                          \
-  V(IDX_QUIC_STREAM_STATS_BYTES_RECEIVED)                                      \
-  V(IDX_QUIC_STREAM_STATS_BYTES_SENT)                                          \
-  V(IDX_QUIC_STREAM_STATS_MAX_OFFSET)                                          \
   V(MAX_RETRYTOKEN_EXPIRATION)                                                 \
   V(MIN_RETRYTOKEN_EXPIRATION)                                                 \
   V(NGTCP2_APP_NOERROR)                                                        \
@@ -236,6 +194,12 @@ void Initialize(Local<Object> target,
   V(QUICSTREAM_HEADERS_KIND_INITIAL)                                           \
   V(QUICSTREAM_HEADERS_KIND_TRAILING)                                          \
   V(UV_EBADF)
+
+#define V(name, _) NODE_DEFINE_CONSTANT(constants, name);
+  SESSION_STATS(V)
+  SOCKET_STATS(V)
+  STREAM_STATS(V)
+#undef V
 
 #define V(name) NODE_DEFINE_CONSTANT(constants, name);
   QUIC_CONSTANTS(V)

--- a/src/quic/node_quic.cc
+++ b/src/quic/node_quic.cc
@@ -1,7 +1,6 @@
 #include "debug_utils.h"
 #include "node.h"
 #include "env-inl.h"
-#include "histogram-inl.h"
 #include "node_crypto.h"  // SecureContext
 #include "node_crypto_common.h"
 #include "node_errors.h"
@@ -75,7 +74,6 @@ void QuicSetCallbacks(const FunctionCallbackInfo<Value>& args) {
 #undef SETFUNCTION
 }
 
-
 // Sets QUIC specific configuration options for the SecureContext.
 // It's entirely likely that there's a better way to do this, but
 // for now this works.
@@ -95,7 +93,6 @@ void QuicInitSecureContext(const FunctionCallbackInfo<Value>& args) {
     THROW_ERR_QUIC_CANNOT_SET_GROUPS(env);
 }
 }  // namespace
-
 
 void Initialize(Local<Object> target,
                 Local<Value> unused,
@@ -195,9 +192,18 @@ void Initialize(Local<Object> target,
   V(QUICSTREAM_HEADERS_KIND_TRAILING)                                          \
   V(UV_EBADF)
 
-#define V(name, _) NODE_DEFINE_CONSTANT(constants, name);
+#define V(name, _)                                                             \
+  NODE_DEFINE_CONSTANT(constants, IDX_QUIC_SESSION_STATS_##name);
   SESSION_STATS(V)
+#undef V
+
+#define V(name, _)                                                             \
+  NODE_DEFINE_CONSTANT(constants, IDX_QUIC_SOCKET_STATS_##name);
   SOCKET_STATS(V)
+#undef V
+
+#define V(name, _)                                                             \
+  NODE_DEFINE_CONSTANT(constants, IDX_QUIC_STREAM_STATS_##name);
   STREAM_STATS(V)
 #undef V
 

--- a/src/quic/node_quic_session-inl.h
+++ b/src/quic/node_quic_session-inl.h
@@ -250,7 +250,7 @@ uint32_t QuicSession::negotiated_version() const {
 // need to do at this point is let the javascript side know.
 void QuicSession::HandshakeCompleted() {
   Debug(this, "Handshake is completed");
-  session_stats_.handshake_completed_at = uv_hrtime();
+  RecordTimestamp(&QuicSessionStats::handshake_completed_at);
   listener()->OnHandshakeCompleted();
 }
 
@@ -362,7 +362,7 @@ bool QuicSession::is_server() const {
 
 void QuicSession::StartGracefulClose() {
   set_flag(QUICSESSION_FLAG_GRACEFUL_CLOSING);
-  session_stats_.closing_at = uv_hrtime();
+  RecordTimestamp(&QuicSessionStats::closing_at);
 }
 
 // The connection ID Strategy is a function that generates
@@ -395,7 +395,7 @@ QuicSocket* QuicSession::socket() const {
 // By default, we keep track of statistics but leave it up to
 // the application to perform specific handling.
 void QuicSession::StreamDataBlocked(int64_t stream_id) {
-  IncrementStat(1, &session_stats_, &session_stats::block_count);
+  IncrementStat(&QuicSessionStats::block_count);
 }
 
 // When a server advertises a preferred address in its initial

--- a/src/quic/node_quic_session.cc
+++ b/src/quic/node_quic_session.cc
@@ -1344,11 +1344,7 @@ QuicSession::QuicSession(
     crypto_handshake_rate_(
         HistogramBase::New(
             socket->env(),
-            1, std::numeric_limits<int64_t>::max())),
-    recovery_stats_buffer_(
-        socket->env()->isolate(),
-        sizeof(recovery_stats_) / sizeof(double),
-        reinterpret_cast<double*>(&recovery_stats_)) {
+            1, std::numeric_limits<int64_t>::max())) {
   PushListener(&default_listener_);
   set_connection_id_strategy(RandomConnectionIDStrategy);
   set_stateless_reset_token_strategy(CryptoStatelessResetTokenStrategy);
@@ -2552,7 +2548,6 @@ void QuicSession::MemoryInfo(MemoryTracker* tracker) const {
   tracker->TrackField("crypto_rx_ack", crypto_rx_ack_);
   tracker->TrackField("crypto_handshake_rate", crypto_handshake_rate_);
   tracker->TrackField("stats_buffer", stats_buffer());
-  tracker->TrackField("recovery_stats_buffer", recovery_stats_buffer_);
   tracker->TrackFieldWithSize("current_ngtcp2_memory", current_ngtcp2_memory_);
   tracker->TrackField("conn_closebuf", conn_closebuf_);
   tracker->TrackField("application", application_);
@@ -2729,9 +2724,9 @@ void QuicSessionOnCertDone(const FunctionCallbackInfo<Value>& args) {
 void QuicSession::UpdateRecoveryStats() {
   const ngtcp2_rcvry_stat* stat =
       ngtcp2_conn_get_rcvry_stat(connection());
-  recovery_stats_.min_rtt = static_cast<double>(stat->min_rtt);
-  recovery_stats_.latest_rtt = static_cast<double>(stat->latest_rtt);
-  recovery_stats_.smoothed_rtt = static_cast<double>(stat->smoothed_rtt);
+  SetStat(&QuicSessionStats::min_rtt, stat->min_rtt);
+  SetStat(&QuicSessionStats::latest_rtt, stat->latest_rtt);
+  SetStat(&QuicSessionStats::smoothed_rtt, stat->smoothed_rtt);
 }
 
 // Data stats are used to allow user code to keep track of important

--- a/src/quic/node_quic_session.h
+++ b/src/quic/node_quic_session.h
@@ -7,7 +7,6 @@
 #include "async_wrap.h"
 #include "env.h"
 #include "handle_wrap.h"
-#include "histogram-inl.h"
 #include "node.h"
 #include "node_crypto.h"
 #include "node_mem.h"
@@ -203,11 +202,11 @@ enum QuicSessionState : int {
   V(HANDSHAKE_CONTINUE_AT, handshake_continue_at)                              \
   V(HANDSHAKE_COMPLETED_AT, handshake_completed_at)                            \
   V(HANDSHAKE_ACKED_AT, handshake_acked_at)                                    \
-  V(SENT_AT,sent_at)                                                           \
+  V(SENT_AT, sent_at)                                                          \
   V(RECEIVED_AT, received_at)                                                  \
   V(CLOSING_AT, closing_at)                                                    \
   V(BYTES_RECEIVED, bytes_received)                                            \
-  V(BYTES_SENT,bytes_sent)                                                     \
+  V(BYTES_SENT, bytes_sent)                                                    \
   V(BIDI_STREAM_COUNT, bidi_stream_count)                                      \
   V(UNI_STREAM_COUNT, uni_stream_count)                                        \
   V(STREAMS_IN_COUNT, streams_in_count)                                        \
@@ -232,10 +231,10 @@ enum QuicSessionStatsIdx : int {
 #undef V
 
 #define V(_, name) uint64_t name;
-  struct QuicSessionStats {
-    SESSION_STATS(V)
-  };
-#undef
+struct QuicSessionStats {
+  SESSION_STATS(V)
+};
+#undef V
 
 class QuicSessionListener {
  public:
@@ -1421,17 +1420,6 @@ class QuicSession : public AsyncWrap,
   StreamsMap streams_;
 
   AliasedFloat64Array state_;
-
-  // crypto_rx_ack_ measures the elapsed time between crypto acks
-  // for this stream. This data can be used to detect peers that are
-  // generally taking too long to acknowledge crypto data.
-  BaseObjectPtr<HistogramBase> crypto_rx_ack_;
-
-  // crypto_handshake_rate_ measures the elapsed time between
-  // crypto continuation steps. This data can be used to detect
-  // peers that are generally taking too long to carry out the
-  // handshake
-  BaseObjectPtr<HistogramBase> crypto_handshake_rate_;
 
   static const ngtcp2_conn_callbacks callbacks[2];
 

--- a/src/quic/node_quic_session.h
+++ b/src/quic/node_quic_session.h
@@ -219,7 +219,10 @@ enum QuicSessionState : int {
   V(PATH_VALIDATION_SUCCESS_COUNT, path_validation_success_count)              \
   V(PATH_VALIDATION_FAILURE_COUNT, path_validation_failure_count)              \
   V(MAX_BYTES_IN_FLIGHT, max_bytes_in_flight)                                  \
-  V(BLOCK_COUNT, block_count)
+  V(BLOCK_COUNT, block_count)                                                  \
+  V(MIN_RTT, min_rtt)                                                          \
+  V(LATEST_RTT, latest_rtt)                                                    \
+  V(SMOOTHED_RTT, smoothed_rtt)
 
 #define V(name, _) IDX_QUIC_SESSION_STATS_##name,
 enum QuicSessionStatsIdx : int {
@@ -1429,15 +1432,6 @@ class QuicSession : public AsyncWrap,
   // peers that are generally taking too long to carry out the
   // handshake
   BaseObjectPtr<HistogramBase> crypto_handshake_rate_;
-
-  struct recovery_stats {
-    double min_rtt;
-    double latest_rtt;
-    double smoothed_rtt;
-  };
-  recovery_stats recovery_stats_{};
-
-  AliasedFloat64Array recovery_stats_buffer_;
 
   static const ngtcp2_conn_callbacks callbacks[2];
 

--- a/src/quic/node_quic_socket-inl.h
+++ b/src/quic/node_quic_socket-inl.h
@@ -195,11 +195,10 @@ void QuicSocket::AddSession(
     BaseObjectPtr<QuicSession> session) {
   sessions_[cid] = session;
   IncrementSocketAddressCounter(session->remote_address());
-  IncrementSocketStat(
-      1, &socket_stats_,
+  IncrementStat(
       session->is_server() ?
-          &socket_stats::server_sessions :
-          &socket_stats::client_sessions);
+          &QuicSocketStats::server_sessions :
+          &QuicSocketStats::client_sessions);
 }
 
 void QuicSocket::AddEndpoint(QuicEndpoint* endpoint_, bool preferred) {

--- a/src/quic/node_quic_socket.cc
+++ b/src/quic/node_quic_socket.cc
@@ -318,7 +318,7 @@ void QuicSocket::MemoryInfo(MemoryTracker* tracker) const {
   tracker->TrackField("reset_counts", reset_counts_);
   tracker->TrackField("token_map", token_map_);
   tracker->TrackField("validated_addrs", validated_addrs_);
-  tracker->TrackField("stats_buffer", stats_buffer());
+  StatsBase::StatsMemoryInfo(tracker);
   tracker->TrackFieldWithSize(
       "current_ngtcp2_memory",
       current_ngtcp2_memory_);

--- a/src/quic/node_quic_socket.h
+++ b/src/quic/node_quic_socket.h
@@ -64,9 +64,9 @@ enum QuicSocketStatsIdx : int {
 #undef V
 
 #define V(_, name) uint64_t name;
-  struct QuicSocketStats {
-    SOCKET_STATS(V)
-  };
+struct QuicSocketStats {
+  SOCKET_STATS(V)
+};
 #undef V
 
 class QuicSocket;

--- a/src/quic/node_quic_stream.h
+++ b/src/quic/node_quic_stream.h
@@ -6,7 +6,6 @@
 #include "memory_tracker-inl.h"
 #include "async_wrap.h"
 #include "env.h"
-#include "histogram-inl.h"
 #include "node_quic_util.h"
 #include "stream_base-inl.h"
 #include "util-inl.h"
@@ -392,27 +391,6 @@ class QuicStream : public AsyncWrap,
   std::vector<std::unique_ptr<QuicHeader>> headers_;
   QuicStreamHeadersKind headers_kind_;
   size_t current_headers_length_ = 0;
-
-  // data_rx_rate_ measures the elapsed time between data packets
-  // for this stream. When used in combination with the data_rx_size,
-  // this can be used to track the overall data throughput over time
-  // for the stream. Specifically, this can be used to detect
-  // potentially bad acting peers that are sending many small chunks
-  // of data too slowly in an attempt to DOS the peer.
-  BaseObjectPtr<HistogramBase> data_rx_rate_;
-
-  // data_rx_size_ measures the size of data packets for this stream
-  // over time. When used in combination with the data_rx_rate_,
-  // this can be used to track the overall data throughout over time
-  // for the stream. Specifically, this can be used to detect
-  // potentially bad acting peers that are sending many small chunks
-  // of data too slowly in an attempt to DOS the peer.
-  BaseObjectPtr<HistogramBase> data_rx_size_;
-
-  // data_rx_ack_ measures the elapsed time between data acks
-  // for this stream. This data can be used to detect peers that are
-  // generally taking too long to acknowledge sent stream data.
-  BaseObjectPtr<HistogramBase> data_rx_ack_;
 
   ListNode<QuicStream> stream_queue_;
 


### PR DESCRIPTION
Unify the statistics code across QuicSocket, QuicSession, and QuicStream into a common base class + simplify implementation.