### PR TITLE
quic: refactor QuicBuffer/QuicStream, fix http3 push

### DIFF
--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -2825,7 +2825,7 @@ class QuicStream extends Duplex {
     // find a way for this to be easily abstracted based on the
     // selected alpn.
 
-    return this[kHandle].submitTrailingHeaders(
+    return this[kHandle].submitTrailers(
       mapToHeaders(headers, assertValidPseudoHeaderTrailer));
   }
 

--- a/node.gyp
+++ b/node.gyp
@@ -622,6 +622,8 @@
         'src/node_api.h',
         'src/node_api_types.h',
         'src/node_binding.h',
+        'src/node_bob.h',
+        'src/node_bob-inl.h',
         'src/node_buffer.h',
         'src/node_constants.h',
         'src/node_context_data.h',

--- a/src/node_bob-inl.h
+++ b/src/node_bob-inl.h
@@ -1,0 +1,37 @@
+#ifndef SRC_NODE_BOB_INL_H_
+#define SRC_NODE_BOB_INL_H_
+
+#include "node_bob.h"
+
+#include <functional>
+
+namespace node {
+namespace bob {
+
+template <typename T>
+int SourceImpl<T>::Pull(
+    Next next,
+    int options,
+    T* data,
+    size_t count,
+    size_t max_count_hint) {
+
+  int status;
+  if (eos_) {
+    status = bob::Status::STATUS_EOS;
+    std::move(next)(status, nullptr, 0, [](size_t len) {});
+    return status;
+  }
+
+  status = DoPull(std::move(next), options, data, count, max_count_hint);
+
+  if (status == bob::Status::STATUS_END)
+    eos_ = true;
+
+  return status;
+}
+
+}  // namespace bob
+}  // namespace node
+
+#endif  // SRC_NODE_BOB_INL_H_

--- a/src/node_bob.h
+++ b/src/node_bob.h
@@ -1,0 +1,109 @@
+#ifndef SRC_NODE_BOB_H_
+#define SRC_NODE_BOB_H_
+
+#include <functional>
+
+namespace node {
+namespace bob {
+
+constexpr size_t kMaxCountHint = 16;
+
+// Negative status codes indicate error conditions.
+enum Status : int {
+  // Indicates that an attempt was made to pull after end.
+  STATUS_EOS = -1,
+
+  // Indicates the end of the stream. No additional
+  // data will be available and the consumer should stop
+  // pulling.
+  STATUS_END = 0,
+
+  // Indicates that there is additional data available
+  // and the consumer may continue to pull.
+  STATUS_CONTINUE = 1,
+
+  // Indicates that there is no additional data available
+  // but the stream has not ended. The consumer should not
+  // continue to pull but may resume pulling later when
+  // data is available.
+  STATUS_BLOCK = 2,
+
+  // Indicates that there is no additional data available
+  // but the stream has not ended and the source will call
+  // next again later when data is available. STATUS_WAIT
+  // must not be used with the OPTIONS_SYNC option.
+  STATUS_WAIT = 3,
+};
+
+enum Options : int {
+  OPTIONS_NONE = 0,
+
+  // Indicates that the consumer is requesting the end
+  // of the stream.
+  OPTIONS_END = 1,
+
+  // Indicates that the consumer requires the source to
+  // invoke Next synchronously. If the source is
+  // unable to provide data immediately but the
+  // stream has not yet ended, it should call Next
+  // using STATUS_BLOCK. When not set, the source
+  // may call Next asynchronously.
+  OPTIONS_SYNC = 2
+};
+
+// There are Sources and there are Consumers.
+//
+// Consumers get data by calling Source::Pull,
+// optionally passing along a status and allocated
+// buffer space for the source to fill, and a Next
+// function the Source will call when data is
+// available.
+//
+// The source calls Next to deliver the data. It can
+// choose to either use the allocated buffer space
+// provided by the consumer or it can allocate its own
+// buffers and push those instead. If it allocates
+// its own, it can send a Done function that the
+// Sink will call when it is done consuming the data.
+template <typename T>
+class Source {
+ public:
+  using Done = std::function<void(size_t)>;
+  using Next = std::function<void(int, const T*, size_t count, Done done)>;
+
+  virtual int Pull(
+      Next next,
+      int options,
+      T* data,
+      size_t count,
+      size_t max_count_hint = kMaxCountHint) = 0;
+};
+
+template <typename T>
+class SourceImpl : public Source<T> {
+ public:
+  int Pull(
+      Next next,
+      int options,
+      T* data,
+      size_t count,
+      size_t max_count_hint = kMaxCountHint) override;
+
+  bool is_eos() const { return eos_; }
+
+ protected:
+  virtual int DoPull(
+      Next next,
+      int options,
+      T* data,
+      size_t count,
+      size_t max_count_hint) = 0;
+
+ private:
+  bool eos_ = false;
+};
+
+}  // namespace bob
+}  // namespace node
+
+#endif  // SRC_NODE_BOB_H_

--- a/src/node_http_common.h
+++ b/src/node_http_common.h
@@ -247,8 +247,12 @@ class NgHeaders {
   inline NgHeaders(Environment* env, v8::Local<v8::Array> headers);
   ~NgHeaders() = default;
 
-  nv_t* operator*() {
-    return reinterpret_cast<nv_t*>(*buf_);
+  const nv_t* operator*() const {
+    return reinterpret_cast<const nv_t*>(*buf_);
+  }
+
+  const nv_t* data() const {
+    return reinterpret_cast<const nv_t*>(*buf_);
   }
 
   size_t length() const {

--- a/src/quic/node_quic_buffer.cc
+++ b/src/quic/node_quic_buffer.cc
@@ -10,57 +10,35 @@
 namespace node {
 namespace quic {
 
-namespace {
-inline bool IsEmptyBuffer(const uv_buf_t& buf) {
-  return buf.len == 0 || buf.base == nullptr;
-}
-}  // namespace
-
 void QuicBufferChunk::MemoryInfo(MemoryTracker* tracker) const {
   tracker->TrackField("data_buf", data_buf_.size());
   tracker->TrackField("next", next_);
 }
 
-QuicBuffer& QuicBuffer::operator+=(QuicBuffer&& src) noexcept {
-  if (tail_ == nullptr) {
-    // If this thing is empty, just do a move...
-    return *this = std::move(src);
-  }
-
-  tail_->next_ = std::move(src.root_);
-  // If head_ is null, then it had been read to the
-  // end, set the new head_ equal to the appended
-  // root.
-  if (head_ == nullptr)
-    head_ = tail_->next_.get();
-  tail_ = src.tail_;
-  length_ += src.length_;
-  Reset(&src);
-  return *this;
-}
-
-size_t QuicBuffer::Push(uv_buf_t* bufs, size_t nbufs, done_cb done) {
+size_t QuicBuffer::push(uv_buf_t* bufs, size_t nbufs, DoneCB done) {
   size_t len = 0;
-  if (nbufs == 0 || bufs == nullptr || IsEmptyBuffer(bufs[0])) {
+  if (nbufs == 0 || bufs == nullptr || is_empty(bufs[0])) {
     done(0);
     return 0;
   }
   size_t n = 0;
   while (nbufs > 1) {
-    if (!IsEmptyBuffer(bufs[n])) {
-      Push(bufs[n]);
+    if (!is_empty(bufs[n])) {
+      push(bufs[n]);
       len += bufs[n].len;
     }
     n++;
     nbufs--;
   }
   len += bufs[n].len;
-  Push(bufs[n], done);
+  push(bufs[n], done);
   return len;
 }
 
-void QuicBuffer::Push(std::unique_ptr<QuicBufferChunk> chunk) {
-  length_ += chunk->buf_.len;
+void QuicBuffer::push(std::unique_ptr<QuicBufferChunk> chunk) {
+  CHECK(!ended_);
+  length_ += chunk->remaining();
+  remaining_ += chunk->remaining();
   if (!tail_) {
     root_ = std::move(chunk);
     head_ = tail_ = root_.get();
@@ -72,27 +50,21 @@ void QuicBuffer::Push(std::unique_ptr<QuicBufferChunk> chunk) {
   }
 }
 
-void QuicBuffer::Seek(ssize_t amount) {
-  // If amount is negative, then we use the full length
-  size_t amt = UNLIKELY(amount < 0) ?
-      length_ :
-      std::min(length_, static_cast<size_t>(amount));
-  while (head_ && amt > 0) {
-    size_t len = head_->buf_.len - head_->roffset_;
-    // If the remaining length in the head is greater than the
-    // amount we're seeking, just adjust the roffset
-    if (len > amt) {
-      head_->roffset_ += amt;
+size_t QuicBuffer::seek(size_t amount) {
+  size_t len = 0;
+  while (head_ && amount > 0) {
+    size_t amt = head_->seek(amount);
+    amount -= amt;
+    len += amt;
+    remaining_ -= amt;
+    if (head_->remaining())
       break;
-    }
-    // Otherwise, decrement the amt and advance the read head
-    // one space and iterate from there.
-    amt -= len;
     head_ = head_->next_.get();
   }
+  return len;
 }
 
-bool QuicBuffer::Pop(int status) {
+bool QuicBuffer::pop(int status) {
   if (!root_)
     return false;
   std::unique_ptr<QuicBufferChunk> root(std::move(root_));
@@ -103,24 +75,28 @@ bool QuicBuffer::Pop(int status) {
   if (tail_ == root.get())
     tail_ = root_.get();
 
-  root->Done(status);
+  root->done(status);
   return true;
 }
 
-void QuicBuffer::Consume(int status, ssize_t amount) {
-  size_t amt = std::min(amount < 0 ? length_ : amount, length_);
+size_t QuicBuffer::consume(int status, size_t amount) {
+  size_t amt = std::min(amount, length_);
+  size_t len = 0;
   while (root_ && amt > 0) {
     auto root = root_.get();
-    size_t len = root->buf_.len - root->offset_;
-    if (len > amt) {
-      length_ -= amt;
-      root->offset_ += amt;
+    size_t consumed = root->consume(amt);
+    len += consumed;
+    length_ -= consumed;
+    amt -= consumed;
+    if (root->length() > 0)
       break;
-    }
-    length_ -= len;
-    amt -= len;
-    Pop(status);
+    pop(status);
   }
+  return len;
+}
+
+void QuicBuffer::MemoryInfo(MemoryTracker* tracker) const {
+  tracker->TrackField("root", root_);
 }
 
 }  // namespace quic

--- a/src/quic/node_quic_buffer.h
+++ b/src/quic/node_quic_buffer.h
@@ -19,7 +19,7 @@ class QuicBuffer;
 
 constexpr size_t kMaxVectorCount = 16;
 
-typedef std::function<void(int status)> done_cb;
+using DoneCB = std::function<void(int)>;
 
 // A QuicBufferChunk contains the actual buffered data
 // along with a callback to be called when the data has
@@ -39,24 +39,41 @@ class QuicBufferChunk : public MemoryRetainer {
   // does not take ownership of the buffer. The done callback
   // is invoked to let the caller know when the chunk is no
   // longer being used.
-  inline QuicBufferChunk(uv_buf_t buf_, done_cb done_);
+  inline QuicBufferChunk(uv_buf_t buf_, DoneCB done_);
 
   inline ~QuicBufferChunk() override;
-  inline void Done(int status);
+
+  inline void done(int status);
+
+  // length() provides the remaining unacknowledged number of bytes.
+  inline size_t length() const { return length_; }
+
+  // remaining() provides the remaining unread number of bytes.
+  inline size_t remaining() const { return buf_.len; }
+
+  // Consumes (acknowledges) the given number of bytes. If amount
+  // is greater than length(), only length() bytes are consumed.
+  // Returns the actual number of bytes consumed.
+  inline size_t consume(size_t amount);
+
+  // Seeks (reads) the given number of bytes. If amount is greater
+  // than remaining(), only remaining() bytes are read. Returns
+  // the actual number of bytes read.
+  inline size_t seek(size_t amount);
 
   uint8_t* out() { return reinterpret_cast<uint8_t*>(buf_.base); }
+  uv_buf_t buf() { return buf_; }
+  const uv_buf_t buf() const { return buf_; }
 
   void MemoryInfo(MemoryTracker* tracker) const override;
-
   SET_MEMORY_INFO_NAME(QuicBufferChunk)
   SET_SELF_SIZE(QuicBufferChunk)
 
  private:
   std::vector<uint8_t> data_buf_;
   uv_buf_t buf_;
-  done_cb done_ = default_done;
-  size_t offset_ = 0;
-  size_t roffset_ = 0;
+  DoneCB done_ = default_done;
+  size_t length_ = 0;
   bool done_called_ = false;
   std::unique_ptr<QuicBufferChunk> next_;
 
@@ -68,9 +85,9 @@ class QuicBufferChunk : public MemoryRetainer {
 //   * root_ is the base of the linked list
 //   * head_ is a pointer to the current read position of the linked list
 //   * tail_ is a pointer to the current write position of the linked list
-// Items are dropped from the linked list only when either Consume() or
-// Cancel() is called. Consume() will consume a given number of bytes up
-// to, but not including the read head_. Cancel() will consume all remaining
+// Items are dropped from the linked list only when either consume() or
+// cancel() is called. consume() will consume a given number of bytes up
+// to, but not including the read head_. cancel() will consume all remaining
 // bytes in the linked list. As whole QuicBufferChunk instances are
 // consumed, the corresponding Done callback will be invoked, allowing
 // any memory to be freed up.
@@ -100,47 +117,49 @@ class QuicBufferChunk : public MemoryRetainer {
 // Will append the contents of buf1 to buf2, then reset buf1
 class QuicBuffer : public MemoryRetainer {
  public:
-  QuicBuffer() {}
+  QuicBuffer() = default;
 
-  QuicBuffer(QuicBuffer&& src) noexcept
-    : head_(src.head_),
-      tail_(src.tail_),
-      length_(src.length_) {
-    root_ = std::move(src.root_);
-    Reset(&src);
-  }
-
+  inline QuicBuffer(QuicBuffer&& src) noexcept;
   inline QuicBuffer& operator=(QuicBuffer&& src) noexcept;
 
-  QuicBuffer& operator+=(QuicBuffer&& src) noexcept;
-
   ~QuicBuffer() override {
-    Cancel();  // Cancel the remaining data
+    cancel();  // Cancel the remaining data
     CHECK_EQ(length_, 0);
   }
 
+  void end() { ended_ = true; }
+  bool is_ended() const { return ended_; }
+
   // Push one or more uv_buf_t instances into the buffer.
-  // the done_cb callback will be invoked when the last
+  // the DoneCB callback will be invoked when the last
   // uv_buf_t in the bufs array is consumed and popped out
   // of the internal linked list.
-  size_t Push(
+  size_t push(
       uv_buf_t* bufs,
       size_t nbufs,
-      done_cb done = QuicBufferChunk::default_done);
+      DoneCB done = QuicBufferChunk::default_done);
 
   // Pushes a single QuicBufferChunk into the linked list
-  void Push(std::unique_ptr<QuicBufferChunk> chunk);
+  void push(std::unique_ptr<QuicBufferChunk> chunk);
 
-  // Consume the given number of bytes within the buffer. If amount is
-  // negative, all buffered bytes that are available to be consumed are
-  // consumed.
-  inline void Consume(ssize_t amount = -1);
+  // Consume the given number of bytes within the buffer. If amount
+  // is greater than length(), length() bytes are consumed. Returns
+  // the actual number of bytes consumed.
+  inline size_t consume(size_t amount);
 
-  // Cancels the remaining bytes within the buffer
-  inline size_t Cancel(int status = UV_ECANCELED);
+  // Cancels the remaining bytes within the buffer.
+  inline size_t cancel(int status = UV_ECANCELED);
 
-  // The total buffered bytes
+  // Seeks (reads) the given number of bytes. If amount is greater
+  // than remaining(), seeks remaining() bytes. Returns the actual
+  // number of bytes read.
+  size_t seek(size_t amount);
+
+  // The total number of unacknowledged bytes remaining.
   size_t length() const { return length_; }
+
+  // The total number of unread bytes remaining.
+  size_t remaining() const { return remaining_; }
 
   // Drain the remaining buffers into the given vector.
   // The function will return the number of positions the
@@ -163,30 +182,26 @@ class QuicBuffer : public MemoryRetainer {
       size_t* length,
       size_t max_count);
 
-  // Returns the current read head or an empty buffer if
-  // we're empty
-  inline uv_buf_t head();
-
-  void Seek(ssize_t amount);
-
-  void MemoryInfo(MemoryTracker* tracker) const override {
-    tracker->TrackField("root", root_);
-  }
+  void MemoryInfo(MemoryTracker* tracker) const override;
   SET_MEMORY_INFO_NAME(QuicBuffer);
   SET_SELF_SIZE(QuicBuffer);
 
  private:
-  void Consume(int status, ssize_t amount);
+  inline static bool is_empty(uv_buf_t buf);
+  size_t consume(int status, size_t amount);
+  bool pop(int status = 0);
+  inline void push(uv_buf_t buf, DoneCB done = nullptr);
+
   template <typename Fn>
   inline size_t DrainInto(Fn&& add_to_list, size_t* length, size_t max_count);
-  bool Pop(int status = 0);
-  inline void Push(uv_buf_t buf, done_cb done = nullptr);
-  inline static void Reset(QuicBuffer* buf);
 
   std::unique_ptr<QuicBufferChunk> root_;
   QuicBufferChunk* head_ = nullptr;  // Current Read Position
   QuicBufferChunk* tail_ = nullptr;  // Current Write Position
+
+  bool ended_ = false;
   size_t length_ = 0;
+  size_t remaining_ = 0;
 
   friend class QuicBufferChunk;
 };

--- a/src/quic/node_quic_buffer.h
+++ b/src/quic/node_quic_buffer.h
@@ -6,6 +6,7 @@
 #include "memory_tracker-inl.h"
 #include "ngtcp2/ngtcp2.h"
 #include "node.h"
+#include "node_bob.h"
 #include "node_internals.h"
 #include "util.h"
 #include "uv.h"
@@ -21,16 +22,79 @@ constexpr size_t kMaxVectorCount = 16;
 
 using DoneCB = std::function<void(int)>;
 
+// When data is sent over QUIC, we are required to retain it in memory
+// until we receive an acknowledgement that it has been successfully
+// acknowledged. The QuicBuffer object is what we use to handle that
+// and track until it is acknowledged. To understand the QuicBuffer
+// object itself, it is important to understand how ngtcp2 and nghttp3
+// handle data that is given to it to serialize into QUIC packets.
+//
+// An individual QUIC packet may contain multiple QUIC frames. Whenever
+// we create a QUIC packet, we really have no idea what frames are going
+// to be encoded or how much buffered handshake or stream data is going
+// to be included within that QuicPacket. If there is buffered data
+// available for a stream, we provide an array of pointers to that data
+// and an indication about how much data is available, then we leave it
+// entirely up to ngtcp2 and nghttp3 to determine how much of the data
+// to encode into the QUIC packet. It is only *after* the QUIC packet
+// is encoded that we can know how much was actually written.
+//
+// Once written to a QUIC Packet, we have to keep the data in memory
+// until an acknowledgement is received. In QUIC, acknowledgements are
+// received per range of packets.
+//
+// QuicBuffer is complicated because it needs to be able to accomplish
+// three things: (a) buffering uv_buf_t instances passed down from
+// JavaScript without memcpy and keeping track of the Write callback
+// associated with each, (b) tracking what data has already been
+// encoded in a QUIC packet and what data is remaining to be read, and
+// (c) tracking which data has been acknowledged and which hasn't.
+// QuicBuffer is further complicated by design quirks and limitations
+// of the StreamBase API and how it interacts with the JavaScript side.
+//
+// QuicBuffer is essentially a linked list of QuicBufferChunk instances.
+// A single QuicBufferChunk wraps a single non-zero-length uv_buf_t.
+// When the QuicBufferChunk is created, we capture the total length
+// of the buffer and the total number of bytes remaining to be sent.
+// Initially, these numbers are identical.
+//
+// When data is encoded into a QuicPacket, we advance the QuicBufferChunk's
+// remaining-to-be-read by the number of bytes actually encoded. If there
+// are no more bytes remaining to be encoded, we move to the next chunk
+// in the linked list.
+//
+// When an acknowledgement is received, we decrement the QuicBufferChunk's
+// length by the number of acknowledged bytes. Once the unacknowledged
+// length reaches 0, we invoke the callback function associated with the
+// QuicBufferChunk (if any).
+//
+// QuicStream is a StreamBase implementation. For every DoWrite call,
+// it receives one or more uv_buf_t instances in a single batch associated
+// with a single write callback. For each uv_buf_t DoWrite gets, a
+// corresponding QuicBufferChunk is added to the QuicBuffer, with the
+// callback associated with the final chunk added to the list.
+
+
 // A QuicBufferChunk contains the actual buffered data
 // along with a callback to be called when the data has
 // been consumed.
+//
+// Any given chunk as a remaining-to-be-acknowledged length (length()) and a
+// remaining-to-be-read-length (remaining()). The former tracks the number
+// of bytes that have yet to be acknowledged by the QUIC peer. Once the
+// remaining-to-be-acknowledged length reaches zero, the done callback
+// associated with the QuicBufferChunk can be called and the QuicBufferChunk
+// can be discarded. The remaining-to-be-read length is adjusted as data is
+// serialized into QUIC packets and sent.
+// The remaining-to-be-acknowledged length is adjusted using consume(),
+// while the remaining-to-be-ead length is adjusted using seek().
 class QuicBufferChunk : public MemoryRetainer {
  public:
   // Default non-op done handler.
   static void default_done(int status) {}
 
   // In this variant, the QuicBufferChunk owns the underlying
-  // data storage within a MaybeStackBuffer. The data will be
+  // data storage within a vector. The data will be
   // freed when the QuicBufferChunk is destroyed.
   inline explicit QuicBufferChunk(size_t len);
 
@@ -43,23 +107,28 @@ class QuicBufferChunk : public MemoryRetainer {
 
   inline ~QuicBufferChunk() override;
 
-  inline void done(int status);
+  // Invokes the done callback associated with the QuicBufferChunk.
+  inline void Done(int status);
 
-  // length() provides the remaining unacknowledged number of bytes.
+  // length() provides the remaining-to-be-acknowledged length.
+  // The QuicBufferChunk must be retained in memory while this
+  // count is greater than zero. The length is adjusted by
+  // calling Consume();
   inline size_t length() const { return length_; }
 
-  // remaining() provides the remaining unread number of bytes.
+  // remaining() provides the remaining-to-be-read length number of bytes.
+  // The length is adjusted by calling Seek()
   inline size_t remaining() const { return buf_.len; }
 
   // Consumes (acknowledges) the given number of bytes. If amount
   // is greater than length(), only length() bytes are consumed.
   // Returns the actual number of bytes consumed.
-  inline size_t consume(size_t amount);
+  inline size_t Consume(size_t amount);
 
   // Seeks (reads) the given number of bytes. If amount is greater
   // than remaining(), only remaining() bytes are read. Returns
   // the actual number of bytes read.
-  inline size_t seek(size_t amount);
+  inline size_t Seek(size_t amount);
 
   uint8_t* out() { return reinterpret_cast<uint8_t*>(buf_.base); }
   uv_buf_t buf() { return buf_; }
@@ -80,42 +149,8 @@ class QuicBufferChunk : public MemoryRetainer {
   friend class QuicBuffer;
 };
 
-// A QuicBuffer is a linked-list of QuicBufferChunk instances.
-// There are three significant pointers: root_, head_, and tail_.
-//   * root_ is the base of the linked list
-//   * head_ is a pointer to the current read position of the linked list
-//   * tail_ is a pointer to the current write position of the linked list
-// Items are dropped from the linked list only when either consume() or
-// cancel() is called. consume() will consume a given number of bytes up
-// to, but not including the read head_. cancel() will consume all remaining
-// bytes in the linked list. As whole QuicBufferChunk instances are
-// consumed, the corresponding Done callback will be invoked, allowing
-// any memory to be freed up.
-//
-// Use Seek(n) to advance the read head_ forward n positions.
-//
-// DrainInto() will drain the remaining QuicBufferChunk instances
-// into a vector and will advance the read head_ to the end of the
-// QuicBuffer. The function will return the number of positions drained
-// which would then be passed to Seek(n) to advance the read head.
-//
-// QuicBuffer supports move assignment that will completely reset the source.
-// That is,
-//  QuicBuffer buf1;
-//  QuicBuffer buf2;
-//  buf2 = std::move(buf1);
-//
-// Will reset the state of buf2 to that of buf1, then reset buf1
-//
-// There is also an overloaded += operator that will append the source
-// content to the destination and reset the source.
-// That is,
-//  QuicBuffer buf1;
-//  QuicBuffer buf2;
-//  buf2 += std::move(buf1);
-//
-// Will append the contents of buf1 to buf2, then reset buf1
-class QuicBuffer : public MemoryRetainer {
+class QuicBuffer : public bob::SourceImpl<ngtcp2_vec>,
+                   public MemoryRetainer {
  public:
   QuicBuffer() = default;
 
@@ -123,37 +158,42 @@ class QuicBuffer : public MemoryRetainer {
   inline QuicBuffer& operator=(QuicBuffer&& src) noexcept;
 
   ~QuicBuffer() override {
-    cancel();  // Cancel the remaining data
+    Cancel();  // Cancel the remaining data
     CHECK_EQ(length_, 0);
   }
 
-  void end() { ended_ = true; }
+  // Marks the QuicBuffer as having ended, preventing new QuicBufferChunk
+  // instances from being appended to the linked list and allowing the
+  // Pull operation to know when to signal that the flow of data is
+  // completed.
+  void End() { ended_ = true; }
   bool is_ended() const { return ended_; }
 
   // Push one or more uv_buf_t instances into the buffer.
   // the DoneCB callback will be invoked when the last
   // uv_buf_t in the bufs array is consumed and popped out
-  // of the internal linked list.
-  size_t push(
+  // of the internal linked list. Ownership of the uv_buf_t
+  // remains with the caller.
+  size_t Push(
       uv_buf_t* bufs,
       size_t nbufs,
       DoneCB done = QuicBufferChunk::default_done);
 
   // Pushes a single QuicBufferChunk into the linked list
-  void push(std::unique_ptr<QuicBufferChunk> chunk);
+  void Push(std::unique_ptr<QuicBufferChunk> chunk);
 
   // Consume the given number of bytes within the buffer. If amount
   // is greater than length(), length() bytes are consumed. Returns
   // the actual number of bytes consumed.
-  inline size_t consume(size_t amount);
+  inline size_t Consume(size_t amount);
 
   // Cancels the remaining bytes within the buffer.
-  inline size_t cancel(int status = UV_ECANCELED);
+  inline size_t Cancel(int status = UV_ECANCELED);
 
   // Seeks (reads) the given number of bytes. If amount is greater
   // than remaining(), seeks remaining() bytes. Returns the actual
   // number of bytes read.
-  size_t seek(size_t amount);
+  size_t Seek(size_t amount);
 
   // The total number of unacknowledged bytes remaining.
   size_t length() const { return length_; }
@@ -161,39 +201,23 @@ class QuicBuffer : public MemoryRetainer {
   // The total number of unread bytes remaining.
   size_t remaining() const { return remaining_; }
 
-  // Drain the remaining buffers into the given vector.
-  // The function will return the number of positions the
-  // read head_ can be advanced.
-  inline size_t DrainInto(
-      std::vector<uv_buf_t>* list,
-      size_t* length = nullptr,
-      size_t max_count = kMaxVectorCount);
-
-  template <typename T>
-  inline size_t DrainInto(
-      std::vector<T>* list,
-      size_t* length,
-      size_t max_count);
-
-  template <typename T>
-  inline size_t DrainInto(
-      T* list,
-      size_t* count,
-      size_t* length,
-      size_t max_count);
-
   void MemoryInfo(MemoryTracker* tracker) const override;
   SET_MEMORY_INFO_NAME(QuicBuffer);
   SET_SELF_SIZE(QuicBuffer);
 
+ protected:
+  int DoPull(
+      Next next,
+      int options,
+      ngtcp2_vec* data,
+      size_t count,
+      size_t max_count_hint) override;
+
  private:
   inline static bool is_empty(uv_buf_t buf);
-  size_t consume(int status, size_t amount);
-  bool pop(int status = 0);
-  inline void push(uv_buf_t buf, DoneCB done = nullptr);
-
-  template <typename Fn>
-  inline size_t DrainInto(Fn&& add_to_list, size_t* length, size_t max_count);
+  size_t Consume(int status, size_t amount);
+  bool Pop(int status = 0);
+  inline void Push(uv_buf_t buf, DoneCB done = nullptr);
 
   std::unique_ptr<QuicBufferChunk> root_;
   QuicBufferChunk* head_ = nullptr;  // Current Read Position

--- a/src/quic/node_quic_session-inl.h
+++ b/src/quic/node_quic_session-inl.h
@@ -73,9 +73,9 @@ QuicCryptoContext::QuicCryptoContext(
 // Cancels and frees any remaining outbound handshake data
 // at each crypto level.
 uint64_t QuicCryptoContext::Cancel() {
-  uint64_t len = handshake_[0].cancel();
-  len += handshake_[1].cancel();
-  len += handshake_[2].cancel();
+  uint64_t len = handshake_[0].Cancel();
+  len += handshake_[1].Cancel();
+  len += handshake_[2].Cancel();
   return len;
 }
 

--- a/src/quic/node_quic_session-inl.h
+++ b/src/quic/node_quic_session-inl.h
@@ -73,9 +73,9 @@ QuicCryptoContext::QuicCryptoContext(
 // Cancels and frees any remaining outbound handshake data
 // at each crypto level.
 uint64_t QuicCryptoContext::Cancel() {
-  uint64_t len = handshake_[0].Cancel();
-  len += handshake_[1].Cancel();
-  len += handshake_[2].Cancel();
+  uint64_t len = handshake_[0].cancel();
+  len += handshake_[1].cancel();
+  len += handshake_[2].cancel();
   return len;
 }
 

--- a/src/quic/node_quic_session.cc
+++ b/src/quic/node_quic_session.cc
@@ -1214,6 +1214,10 @@ void QuicApplication::MaybeSetFin(const StreamData& stream_data) {
     set_stream_fin(stream_data.id);
 }
 
+void QuicApplication::StreamOpen(int64_t stream_id) {
+  Debug(session(), "QUIC Stream %" PRId64 " is open.");
+}
+
 void QuicApplication::StreamHeaders(
     int64_t stream_id,
     int kind,

--- a/src/quic/node_quic_session.cc
+++ b/src/quic/node_quic_session.cc
@@ -761,7 +761,7 @@ void QuicCryptoContext::AcknowledgeCryptoData(
         crypto_level_name(level));
 
   // Consumes (frees) the given number of bytes in the handshake buffer.
-  handshake_[level].Consume(datalen);
+  handshake_[level].consume(datalen);
 
   // Update the statistics for the handshake, allowing us to track
   // how long the handshake is taking to be acknowledged. A malicious
@@ -1096,7 +1096,7 @@ void QuicCryptoContext::WriteHandshake(
           level,
           buffer->out(),
           datalen), 0);
-  handshake_[level].Push(std::move(buffer));
+  handshake_[level].push(std::move(buffer));
 }
 
 void QuicApplication::Acknowledge(

--- a/src/quic/node_quic_session.cc
+++ b/src/quic/node_quic_session.cc
@@ -761,7 +761,7 @@ void QuicCryptoContext::AcknowledgeCryptoData(
         crypto_level_name(level));
 
   // Consumes (frees) the given number of bytes in the handshake buffer.
-  handshake_[level].consume(datalen);
+  handshake_[level].Consume(datalen);
 
   // Update the statistics for the handshake, allowing us to track
   // how long the handshake is taking to be acknowledged. A malicious
@@ -1096,7 +1096,7 @@ void QuicCryptoContext::WriteHandshake(
           level,
           buffer->out(),
           datalen), 0);
-  handshake_[level].push(std::move(buffer));
+  handshake_[level].Push(std::move(buffer));
 }
 
 void QuicApplication::Acknowledge(

--- a/src/quic/node_quic_session.h
+++ b/src/quic/node_quic_session.h
@@ -529,7 +529,7 @@ class QuicApplication : public MemoryRetainer {
   virtual void StreamClose(
       int64_t stream_id,
       uint64_t app_error_code);
-  virtual void StreamOpen(int64_t stream_id) {}
+  virtual void StreamOpen(int64_t stream_id);
   virtual void StreamReset(
       int64_t stream_id,
       uint64_t final_size,
@@ -1026,6 +1026,10 @@ class QuicSession : public AsyncWrap,
   // Report that the stream data is flow control blocked
   inline void StreamDataBlocked(int64_t stream_id);
 
+  // SendSessionScope triggers SendPendingData() when not executing
+  // within the context of an ngtcp2 callback. When within an ngtcp2
+  // callback, SendPendingData will always be called when the callbacks
+  // complete.
   class SendSessionScope {
    public:
     explicit SendSessionScope(QuicSession* session) : session_(session) {

--- a/src/quic/node_quic_stream-inl.h
+++ b/src/quic/node_quic_stream-inl.h
@@ -127,7 +127,7 @@ void QuicStream::BeginHeaders(QuicStreamHeadersKind kind) {
 
 void QuicStream::Commit(size_t amount) {
   CHECK(!is_destroyed());
-  streambuf_.seek(amount);
+  streambuf_.Seek(amount);
 }
 
 void QuicStream::ResetStream(uint64_t app_error_code) {
@@ -137,29 +137,8 @@ void QuicStream::ResetStream(uint64_t app_error_code) {
   // to be acknowledged at the ngtcp2 level will be
   // abandoned.
   set_flag(QUICSTREAM_FLAG_READ_CLOSED);
-  streambuf_.end();
+  streambuf_.End();
   session_->ResetStream(stream_id_, app_error_code);
-}
-
-template <typename T>
-size_t QuicStream::DrainInto(
-    std::vector<T>* vec,
-    size_t max_count) {
-  CHECK(!is_destroyed());
-  size_t length = 0;
-  streambuf_.DrainInto(vec, &length, max_count);
-  return length;
-}
-
-template <typename T>
-size_t QuicStream::DrainInto(
-    T* vec,
-    size_t* count,
-    size_t max_count) {
-  CHECK(!is_destroyed());
-  size_t length = 0;
-  streambuf_.DrainInto(vec, count, &length, max_count);
-  return length;
 }
 
 void QuicStream::Schedule(Queue* queue) {

--- a/src/quic/node_quic_stream.h
+++ b/src/quic/node_quic_stream.h
@@ -192,6 +192,7 @@ enum QuicStreamOrigin {
 // abandoned, and causes the QuicStream to be immediately closed at the
 // ngtcp2 level.
 class QuicStream : public AsyncWrap,
+                   public bob::SourceImpl<ngtcp2_vec>,
                    public StreamBase,
                    public StatsBase<QuicStreamStats> {
  public:
@@ -288,17 +289,6 @@ class QuicStream : public AsyncWrap,
   // submitted to the QUIC connection.
   inline void Commit(size_t amount);
 
-  template <typename T>
-  inline size_t DrainInto(
-      std::vector<T>* vec,
-      size_t max_count = kMaxVectorCount);
-
-  template <typename T>
-  inline size_t DrainInto(
-      T* vec,
-      size_t* count,
-      size_t max_count = kMaxVectorCount);
-
   inline void EndHeaders(int64_t push_id = 0);
 
   // Passes a chunk of data on to the QuicStream listener.
@@ -339,6 +329,14 @@ class QuicStream : public AsyncWrap,
   void MemoryInfo(MemoryTracker* tracker) const override;
   SET_MEMORY_INFO_NAME(QuicStream)
   SET_SELF_SIZE(QuicStream)
+
+ protected:
+  int DoPull(
+      Next next,
+      int options,
+      ngtcp2_vec* data,
+      size_t count,
+      size_t max_count_hint) override;
 
  private:
   inline bool is_flag_set(int32_t flag) const;

--- a/src/quic/node_quic_util-inl.h
+++ b/src/quic/node_quic_util-inl.h
@@ -409,6 +409,15 @@ void StatsBase<T>::StatsMemoryInfo(MemoryTracker* tracker) const {
   tracker->TrackField("ack_histogram", ack_);
 }
 
+template <typename T>
+size_t get_length(const T* vec, size_t count) {
+  CHECK_NOT_NULL(vec);
+  size_t len = 0;
+  for (size_t n = 0; n < count; n++)
+    len += vec[n].len;
+  return len;
+}
+
 }  // namespace quic
 }  // namespace node
 

--- a/src/quic/node_quic_util.h
+++ b/src/quic/node_quic_util.h
@@ -330,6 +330,9 @@ template <typename T>
 using QuicCIDMap =
     std::unordered_map<QuicCID, T, QuicCID::Hash, QuicCID::Compare>;
 
+template <typename T>
+inline size_t get_length(const T*, size_t len);
+
 }  // namespace quic
 }  // namespace node
 

--- a/test/parallel/test-quic-http3-push.js
+++ b/test/parallel/test-quic-http3-push.js
@@ -39,10 +39,13 @@ server.on('session', common.mustCall((session) => {
     });
     assert(push);
     push.submitInitialHeaders({ ':status': '200' });
-    // TODO(@jasnell): There's currently a bug if we only call end() to write.
-    // push.write('push ');
-    push.write('test');
-    push.end('ing');
+    // TODO(@jasnell): If we call write('test') followed by end('ing')
+    // things work great. However, if we call end('testing) only, the
+    // client does not receive the frames in the right order and there
+    // are some definite processing problems. Putting the end('testing')
+    // in a setImmediate(), it works, so there's some weird timing issue
+    // at play that's rather difficult to track down.
+    setImmediate(() => push.end('testing'));
     push.on('close', common.mustCall());
     push.on('finish', common.mustCall());
 


### PR DESCRIPTION
Working through some issues with the Http3Application, specifically with push but the issue likely effects more than that and is only triggered with push streams.

Specifically, 

Given the following code running on the server inside the `session.on('stream')` event, the client receives the data `testing` as expected and the stream on the client side closes normally as expected.

```js
    const push = stream.pushStream({
      ':method': 'GET',
      ':scheme': 'https',
      ':authority': 'localhost',
      ':path': '/foo'
    });
    assert(push);
    push.submitInitialHeaders({ ':status': '200' });
    push.write('test');
    push.end('ing');
    push.on('close', common.mustCall());
    push.on('finish', common.mustCall());
```

However, if we switch to either of the two following, the data is delivered to the client side but the close, headers, and data are delivered out of order causing issues and stopping the push stream from closing normally on the client.

```js
    const push = stream.pushStream({
      ':method': 'GET',
      ':scheme': 'https',
      ':authority': 'localhost',
      ':path': '/foo'
    });
    assert(push);
    push.submitInitialHeaders({ ':status': '200' });
    push.write('');
    push.end('testing');
    push.on('close', common.mustCall());
    push.on('finish', common.mustCall());
```

```js
    const push = stream.pushStream({
      ':method': 'GET',
      ':scheme': 'https',
      ':authority': 'localhost',
      ':path': '/foo'
    });
    assert(push);
    push.submitInitialHeaders({ ':status': '200' });
    push.end('testing');
    push.on('close', common.mustCall());
    push.on('finish', common.mustCall());
```

Wrapping the `push.end('testing')` in a `setImmediate()`, however, causes the code to work.

```js
    const push = stream.pushStream({
      ':method': 'GET',
      ':scheme': 'https',
      ':authority': 'localhost',
      ':path': '/foo'
    });
    assert(push);
    push.submitInitialHeaders({ ':status': '200' });
    setImmediate(() => push.end('testing'));
    push.on('close', common.mustCall());
    push.on('finish', common.mustCall());
```

To complicate things, writing only with `end('hello world')` on the bidirectional request/response stream appears to work perfectly, so the issue *appears* to be limited to the unidirectional push streams.

On the server side, it *appears* that the data for the push stream is being serialized correctly to a QUIC packet and sent to the client. A QUIC packet with an appropriate fin flag is also sent. The client QuicSession also successfully receives the data and the fin. The *challenge*, however, appears to be the fact that in the push promise and response headers are delivered on a *different* QUIC stream and there are timing differences between when the *data* on the push stream is sent and when the *headers* for that stream are sent and processed, causing some weird processing issue on the client side.

It's *POSSIBLE* that we're seeing a bug in nghttp3 with regards to unidirectional push streams -- there was another bug that I uncovered a couple days ago in nghttp3 in relation to unidirectional streams, but it's really not yet clear.