### PR TITLE
src: initial support for setting ipv6 flow label

### DIFF
--- a/src/node_sockaddr-inl.h
+++ b/src/node_sockaddr-inl.h
@@ -12,6 +12,8 @@
 
 namespace node {
 
+static constexpr uint32_t kLabelMask = 0xFFFFF;
+
 // Fun hash combine trick based on a variadic template that
 // I came across a while back but can't remember where. Will add an attribution
 // if I can find the source.
@@ -115,10 +117,9 @@ uint32_t SocketAddress::flow_label() const {
 }
 
 void SocketAddress::set_flow_label(uint32_t label) {
-  static constexpr uint32_t kMaxLabel = 1048575;
   if (family() != AF_INET6)
     return;
-  CHECK_LE(label, kMaxLabel);
+  CHECK_LE(label, kLabelMask);
   sockaddr_in6* in = reinterpret_cast<sockaddr_in6*>(&address_);
   in->sin6_flowinfo = label;
 }

--- a/src/node_sockaddr-inl.h
+++ b/src/node_sockaddr-inl.h
@@ -107,6 +107,22 @@ int SocketAddress::port() const {
   return GetPort(&address_);
 }
 
+uint32_t SocketAddress::flow_label() const {
+  if (family() != AF_INET6)
+    return 0;
+  const sockaddr_in6* in = reinterpret_cast<const sockaddr_in6*>(data());
+  return in->sin6_flowinfo;
+}
+
+void SocketAddress::set_flow_label(uint32_t label) {
+  static constexpr uint32_t kMaxLabel = 1048575;
+  if (family() != AF_INET6)
+    return;
+  CHECK_LE(label, kMaxLabel);
+  sockaddr_in6* in = reinterpret_cast<sockaddr_in6*>(&address_);
+  in->sin6_flowinfo = label;
+}
+
 std::string SocketAddress::ToString() const {
   return address() + ":" + std::to_string(port());
 }

--- a/src/node_sockaddr.h
+++ b/src/node_sockaddr.h
@@ -83,6 +83,21 @@ class SocketAddress : public MemoryRetainer {
 
   inline int port() const;
 
+  // If the SocketAddress is an IPv6 address, returns the
+  // current value of the IPv6 flow label, if set. Otherwise
+  // returns 0.
+  inline uint32_t flow_label() const;
+
+  // If the SocketAddress is an IPv6 address, sets the
+  // current value of the IPv6 flow label. If not an
+  // IPv6 address, set_flow_label is a non-op. It
+  // is important to note that the flow label,
+  // while represented as an uint32_t, the flow
+  // label is strictly limited to 20 bits, and
+  // this will assert if any value larger than
+  // 20-bits is specified.
+  inline void set_flow_label(uint32_t label = 0);
+
   inline void Update(uint8_t* data, size_t len);
 
   template <typename T>

--- a/src/quic/node_quic_crypto.h
+++ b/src/quic/node_quic_crypto.h
@@ -85,6 +85,13 @@ bool GenerateRetryToken(
     const QuicCID& ocid,
     const uint8_t* token_secret);
 
+uint32_t GenerateFlowLabel(
+    const SocketAddress& local,
+    const SocketAddress& remote,
+    const QuicCID& cid,
+    const uint8_t* secret,
+    size_t secretlen);
+
 // Verifies the validity of a retry token. Returns true if the
 // token is not valid, false otherwise.
 bool InvalidRetryToken(

--- a/test/cctest/test_sockaddr.cc
+++ b/test/cctest/test_sockaddr.cc
@@ -20,6 +20,9 @@ TEST(SocketAddress, SocketAddress) {
   CHECK_EQ(addr.address(), "123.123.123.123");
   CHECK_EQ(addr.port(), 443);
 
+  addr.set_flow_label(12345);
+  CHECK_EQ(addr.flow_label(), 0);
+
   CHECK(!SocketAddress::Compare()(addr, addr2));
   CHECK(SocketAddress::Compare()(addr, addr));
 
@@ -36,4 +39,19 @@ TEST(SocketAddress, SocketAddress) {
   map[addr]++;
   map[addr]++;
   CHECK_EQ(map[addr], 2);
+}
+
+TEST(SocketAddress, SocketAddressIPv6) {
+  sockaddr_storage storage;
+  SocketAddress::ToSockAddr(AF_INET6, "::1", 443, &storage);
+
+  SocketAddress addr(reinterpret_cast<const sockaddr*>(&storage));
+
+  CHECK_EQ(addr.length(), sizeof(sockaddr_in6));
+  CHECK_EQ(addr.family(), AF_INET6);
+  CHECK_EQ(addr.address(), "::1");
+  CHECK_EQ(addr.port(), 443);
+
+  addr.set_flow_label(12345);
+  CHECK_EQ(addr.flow_label(), 12345);
 }


### PR DESCRIPTION
QUIC recommends setting the IPv6 flow label in various cases.
