### PR TITLE
quic: fixup test-quic-quicsocket

### DIFF
--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -1120,19 +1120,26 @@ class QuicSocket extends EventEmitter {
     if (this.#state === kSocketClosing)
       throw new ERR_QUICSOCKET_CLOSING('listen');
 
-    // Bind the QuicSocket to the local port if it hasn't been bound already.
-    this[kMaybeBind]();
-
     options = {
       secureProtocol: 'TLSv1_3_server_method',
       ...this.#server,
       ...options
     };
 
-    const { alpn = NGTCP2_ALPN_H3 } = options;
     // The ALPN protocol identifier is strictly required.
+    const { alpn = NGTCP2_ALPN_H3 } = options;
     if (typeof alpn !== 'string')
       throw new ERR_INVALID_ARG_TYPE('options.alpn', 'string', alpn);
+
+    // Store the secure context so that it is not garbage collected
+    // while we still need to make use of it.
+    // TODO(@jasnell): We could store a reference at the C++ level instead
+    // since we do not need to access this anywhere else.
+    // The secure context options will be validated. Keep this before the
+    // kMaybeBind call below.
+    this.#serverSecureContext = createSecureContext(options, initSecureContext);
+    this.#serverListening = true;
+    this.#alpn = alpn;
 
     // If the callback function is provided, it is registered as a
     // handler for the on('session') event and will be called whenever
@@ -1140,13 +1147,9 @@ class QuicSocket extends EventEmitter {
     if (callback)
       this.on('session', callback);
 
-    // Store the secure context so that it is not garbage collected
-    // while we still need to make use of it.
-    // TODO(@jasnell): We could store a reference at the C++ level instead
-    // since we do not need to access this anywhere else.
-    this.#serverSecureContext = createSecureContext(options, initSecureContext);
-    this.#serverListening = true;
-    this.#alpn = alpn;
+    // Bind the QuicSocket to the local port if it hasn't been bound already.
+    this[kMaybeBind]();
+
     const doListen =
       continueListen.bind(
         this,

--- a/test/parallel/test-quic-quicsocket.js
+++ b/test/parallel/test-quic-quicsocket.js
@@ -105,12 +105,8 @@ assert.throws(() => socket.setDiagnosticPacketLoss({ tx: 1.1 }), {
 });
 
 [1, 1n, [], {}, null].forEach((args) => {
-  const message = 'The "on" argument must be of type boolean.' +
-                  ' Received type ' + typeof args;
-
   assert.throws(() => socket.setServerBusy(args), {
-    code: 'ERR_INVALID_ARG_TYPE',
-    message
+    code: 'ERR_INVALID_ARG_TYPE'
   });
 });
 


### PR DESCRIPTION
Avoid memory leak on ready listeners by moving all arg
validation before kMaybeBind call

