### PR TITLE
quic: fix stream abort

### DIFF
--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -1835,19 +1835,6 @@ added: REPLACEME
 
 * Extends: {stream.Duplex}
 
-#### Event: `'abort'`
-<!-- YAML
-added: REPLACEME
--->
-
-Emitted when the `QuicStream` is closed abruptly before the readable
-or writable side has closed naturally.
-
-The callback is invoked with two arguments:
-
-* `code` {number} The QUIC application error code used to terminate the stream.
-* `family` {number} Identifier of the error code family.
-
 #### Event: `'blocked'`
 <!-- YAML
 added: REPLACEME

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -2479,10 +2479,6 @@ class QuicStream extends Duplex {
     // empty STREAM frame with fin set to be sent to the peer.
     if (this.writable)
       this.end();
-
-    // Finally, emit the abort event if necessary
-    if (this.#aborted)
-      process.nextTick(emit.bind(this, 'abort', code, family));
   }
 
   get pending() {

--- a/src/quic/node_quic_stream-inl.h
+++ b/src/quic/node_quic_stream-inl.h
@@ -134,6 +134,7 @@ void QuicStream::ResetStream(uint64_t app_error_code) {
   // to be acknowledged at the ngtcp2 level will be
   // abandoned.
   set_flag(QUICSTREAM_FLAG_READ_CLOSED);
+  streambuf_.Cancel();
   streambuf_.End();
   session_->ResetStream(stream_id_, app_error_code);
 }

--- a/test/parallel/test-quic-stream-close-early.js
+++ b/test/parallel/test-quic-stream-close-early.js
@@ -44,14 +44,12 @@ server.on('session', common.mustCall((session) => {
 
   session.on('secure', common.mustCall((servername, alpn, cipher) => {
     const uni = session.openStream({ halfOpen: true });
+
+    // TODO(@jasnell): There's still a bug in here somewhere. If we
+    // comment out the following line and close without writing
+    // anything, the test hangs.
     uni.write('hi', common.mustCall());
     uni.close(3);
-
-    uni.on('abort', common.mustCall((code, finalSize) => {
-      debug('Undirectional, Server-initiated stream %d aborted', uni.id);
-      assert.strictEqual(code, 3);
-      assert.strictEqual(finalSize, 2);
-    }));
 
     uni.on('data', common.mustNotCall());
 
@@ -63,7 +61,9 @@ server.on('session', common.mustCall((session) => {
       debug('Unidirectional, Server-initiated stream %d closed on server',
             uni.id);
     }));
-    uni.on('error', common.mustNotCall());
+    uni.on('error', common.mustCall(() => {
+      assert.strictEqual(uni.aborted, true);
+    }));
 
     debug('Unidirectional, Server-initiated stream %d opened', uni.id);
   }));
@@ -96,22 +96,16 @@ server.on('ready', common.mustCall(() => {
     stream.write('hello', common.mustCall());
     stream.close(1);
 
-    // The abort event should emit because the stream closed abruptly
-    // before the stream was finished.
-    stream.on('abort', common.mustCall((code, finalSize) => {
-      debug('Bidirectional, Client-initated stream %d aborted', stream.id);
-      assert.strictEqual(code, 1);
-      countdown.dec();
-    }));
+    stream.on('end', common.mustNotCall());
 
-    stream.on('end', common.mustCall(() => {
-      debug('Bidirectional, Client-initiated stream %d ended on client',
-            stream.id);
+    stream.on('error', common.mustCall(() => {
+      assert.strictEqual(stream.aborted, true);
     }));
 
     stream.on('close', common.mustCall(() => {
       debug('Bidirectional, Client-initiated stream %d closed on client',
             stream.id);
+      countdown.dec();
     }));
 
     debug('Bidirectional, Client-initiated stream %d opened', stream.id);


### PR DESCRIPTION
Fixed a bug in stream reset and refactored the abort event out.
