### PR TITLE
quic: support captureRejections

### DIFF
--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -984,7 +984,7 @@ class QuicSocket extends EventEmitter {
       // When true, stateless resets will not be sent (default false)
       disableStatelessReset,
     } = validateQuicSocketOptions(options);
-    super();
+    super({ captureRejections: true });
     this.#autoClose = autoClose;
     this.#client = client;
     this.#lookup = lookup || (type === AF_INET6 ? lookup6 : lookup4);
@@ -1545,7 +1545,7 @@ class QuicSession extends EventEmitter {
   #handshakeContinuationHistogram = undefined;
 
   constructor(socket, servername, alpn) {
-    super();
+    super({ captureRejections: true });
     this.on('newListener', onNewListener);
     this.on('removeListener', onRemoveListener);
     this.#socket = socket;


### PR DESCRIPTION
Enable captureRejections on QuicSocket, QuicSession, and QuicStream