### PR TITLE
src: clean up SocketAddress usage a bit

### DIFF
--- a/src/js_udp_wrap.cc
+++ b/src/js_udp_wrap.cc
@@ -26,11 +26,8 @@ class JSUDPWrap final : public UDPWrapBase, public AsyncWrap {
   ssize_t Send(uv_buf_t* bufs,
                size_t nbufs,
                const sockaddr* addr) override;
-  int GetPeerName(sockaddr* name, int* namelen) override;
-  int GetSockName(sockaddr* name, int* namelen) override;
-  SocketAddress* GetPeerName(SocketAddress* addr = nullptr) override;
-  SocketAddress* GetSockName(SocketAddress* addr = nullptr) override;
-  int GetSockaddr(sockaddr* name, int* namelen, bool peer);
+  SocketAddress GetPeerName() override;
+  SocketAddress GetSockName() override;
   AsyncWrap* GetAsyncWrap() override { return this; }
 
   static void New(const FunctionCallbackInfo<Value>& args);
@@ -115,32 +112,18 @@ ssize_t JSUDPWrap::Send(uv_buf_t* bufs,
   return value_int;
 }
 
-int JSUDPWrap::GetPeerName(sockaddr* name, int* namelen) {
-  return GetSockaddr(name, namelen, true);
-}
-
-int JSUDPWrap::GetSockName(sockaddr* name, int* namelen) {
-  return GetSockaddr(name, namelen, false);
-}
-
-SocketAddress* JSUDPWrap::GetPeerName(SocketAddress* addr) {
+SocketAddress JSUDPWrap::GetPeerName() {
   // TODO(jasnell): Maybe turn this into a real JS-based method.
-  return SocketAddress::New("127.0.0.1", 1337, AF_INET, addr);
+  SocketAddress ret;
+  CHECK(SocketAddress::New(AF_INET, "127.0.0.1", 1337, &ret));
+  return ret;
 }
 
-SocketAddress* JSUDPWrap::GetSockName(SocketAddress* addr) {
+SocketAddress JSUDPWrap::GetSockName() {
   // TODO(jasnell): Maybe turn this into a real JS-based method.
-  return SocketAddress::New("127.0.0.1", 1337, AF_INET, addr);
-}
-
-int JSUDPWrap::GetSockaddr(sockaddr* name, int* namelen, bool peer) {
-  // TODO(addaleax): Maybe turn this into a real JS-based method.
-  sockaddr_in addr_in;
-  CHECK_EQ(uv_ip4_addr("127.0.0.1", 1337, &addr_in), 0);
-  memcpy(name, &addr_in,
-         std::min(static_cast<size_t>(*namelen), sizeof(addr_in)));
-  *namelen = sizeof(addr_in);
-  return 0;
+  SocketAddress ret;
+  CHECK(SocketAddress::New(AF_INET, "127.0.0.1", 1337, &ret));
+  return ret;
 }
 
 void JSUDPWrap::New(const FunctionCallbackInfo<Value>& args) {

--- a/src/node_sockaddr.cc
+++ b/src/node_sockaddr.cc
@@ -5,19 +5,18 @@ namespace node {
 
 namespace {
 template <typename T, typename F>
-SocketAddress* FromUVHandle(
-    F fn,
-    const T* handle,
-    SocketAddress* addr) {
-  if (addr == nullptr)
-    addr = new SocketAddress();
+SocketAddress FromUVHandle(F fn, const T& handle) {
+  SocketAddress addr;
   int len = sizeof(sockaddr_storage);
-  fn(handle, addr->storage(), &len);
+  if (fn(&handle, addr.storage(), &len) == 0)
+    CHECK_EQ(static_cast<size_t>(len), addr.length());
+  else
+    addr.storage()->sa_family = 0;
   return addr;
 }
 }  // namespace
 
-sockaddr_storage* SocketAddress::ToSockAddr(
+bool SocketAddress::ToSockAddr(
     int32_t family,
     const char* host,
     uint32_t port,
@@ -27,48 +26,38 @@ sockaddr_storage* SocketAddress::ToSockAddr(
       return uv_ip4_addr(
           host,
           port,
-          reinterpret_cast<sockaddr_in*>(addr)) == 0 ?
-              addr : nullptr;
+          reinterpret_cast<sockaddr_in*>(addr)) == 0;
     case AF_INET6:
       return uv_ip6_addr(
           host,
           port,
-          reinterpret_cast<sockaddr_in6*>(addr)) == 0 ?
-              addr : nullptr;
+          reinterpret_cast<sockaddr_in6*>(addr)) == 0;
     default:
       UNREACHABLE();
   }
 }
 
-bool SocketAddress::Compare::operator()(
-    const SocketAddress& laddr,
-    const SocketAddress& raddr) const {
-  return Compare()(laddr.data(), raddr.data());
-}
-
-bool SocketAddress::Compare::operator()(
-    const sockaddr* laddr,
-    const sockaddr* raddr) const {
-  CHECK(laddr->sa_family == AF_INET || laddr->sa_family == AF_INET6);
-  return memcmp(laddr, raddr, GetLength(laddr)) == 0;
+bool SocketAddress::New(
+    int32_t family,
+    const char* host,
+    uint32_t port,
+    SocketAddress* addr) {
+  return ToSockAddr(family, host, port,
+                    reinterpret_cast<sockaddr_storage*>(addr->storage()));
 }
 
 size_t SocketAddress::Hash::operator()(const SocketAddress& addr) const {
-  return Hash()(addr.data());
-}
-
-size_t SocketAddress::Hash::operator()(const sockaddr* addr) const {
   size_t hash = 0;
-  switch (addr->sa_family) {
+  switch (addr.family()) {
     case AF_INET: {
       const sockaddr_in* ipv4 =
-          reinterpret_cast<const sockaddr_in*>(addr);
+          reinterpret_cast<const sockaddr_in*>(addr.raw());
       hash_combine(&hash, ipv4->sin_port, ipv4->sin_addr.s_addr);
       break;
     }
     case AF_INET6: {
       const sockaddr_in6* ipv6 =
-          reinterpret_cast<const sockaddr_in6*>(addr);
+          reinterpret_cast<const sockaddr_in6*>(addr.raw());
       const uint64_t* a =
           reinterpret_cast<const uint64_t*>(&ipv6->sin6_addr);
       hash_combine(&hash, ipv6->sin6_port, a[0], a[1]);
@@ -80,85 +69,20 @@ size_t SocketAddress::Hash::operator()(const sockaddr* addr) const {
   return hash;
 }
 
-template <>
-SocketAddress* SocketAddress::FromSockName<uv_tcp_t>(
-    const uv_tcp_t* handle,
-    SocketAddress* addr) {
-  return FromUVHandle<uv_tcp_t>(uv_tcp_getsockname, handle, addr);
+SocketAddress SocketAddress::FromSockName(const uv_tcp_t& handle) {
+  return FromUVHandle(uv_tcp_getsockname, handle);
 }
 
-template <>
-SocketAddress* SocketAddress::FromSockName<uv_udp_t>(
-    const uv_udp_t* handle,
-    SocketAddress* addr) {
-  return FromUVHandle<uv_udp_t>(uv_udp_getsockname, handle, addr);
+SocketAddress SocketAddress::FromSockName(const uv_udp_t& handle) {
+  return FromUVHandle(uv_udp_getsockname, handle);
 }
 
-template <>
-SocketAddress* SocketAddress::FromSockName<uv_tcp_t>(
-    const uv_tcp_t& handle,
-    SocketAddress* addr) {
-  return FromUVHandle<uv_tcp_t>(uv_tcp_getsockname, &handle, addr);
+SocketAddress SocketAddress::FromPeerName(const uv_tcp_t& handle) {
+  return FromUVHandle(uv_tcp_getpeername, handle);
 }
 
-template <>
-SocketAddress* SocketAddress::FromSockName<uv_udp_t>(
-    const uv_udp_t& handle,
-    SocketAddress* addr) {
-  return FromUVHandle<uv_udp_t>(uv_udp_getsockname, &handle, addr);
-}
-
-template <>
-SocketAddress* SocketAddress::FromPeerName<uv_tcp_t>(
-    const uv_tcp_t* handle,
-    SocketAddress* addr) {
-  return FromUVHandle<uv_tcp_t>(uv_tcp_getpeername, handle, addr);
-}
-
-template <>
-SocketAddress* SocketAddress::FromPeerName<uv_tcp_t>(
-    const uv_tcp_t& handle,
-    SocketAddress* addr) {
-  return FromUVHandle<uv_tcp_t>(uv_tcp_getpeername, &handle, addr);
-}
-
-template <>
-SocketAddress* SocketAddress::FromPeerName<uv_udp_t>(
-    const uv_udp_t* handle,
-    SocketAddress* addr) {
-  return FromUVHandle<uv_udp_t>(uv_udp_getpeername, handle, addr);
-}
-
-template <>
-SocketAddress* SocketAddress::FromPeerName<uv_udp_t>(
-    const uv_udp_t& handle,
-    SocketAddress* addr) {
-  return FromUVHandle<uv_udp_t>(uv_udp_getpeername, &handle, addr);
-}
-
-SocketAddress* SocketAddress::New(
-    const char* host,
-    uint32_t port,
-    int32_t family,
-    SocketAddress* addr) {
-  if (addr == nullptr)
-    addr = new SocketAddress();
-  switch (family) {
-    case AF_INET:
-      return uv_ip4_addr(
-          host,
-          port,
-          reinterpret_cast<sockaddr_in*>(&addr->address_)) == 0 ?
-              addr : nullptr;
-    case AF_INET6:
-      return uv_ip6_addr(
-          host,
-          port,
-          reinterpret_cast<sockaddr_in6*>(&addr->address_)) == 0 ?
-              addr : nullptr;
-    default:
-      UNREACHABLE();
-  }
+SocketAddress SocketAddress::FromPeerName(const uv_udp_t& handle) {
+  return FromUVHandle(uv_udp_getpeername, handle);
 }
 
 }  // namespace node

--- a/src/quic/node_quic_session.cc
+++ b/src/quic/node_quic_session.cc
@@ -3488,7 +3488,8 @@ void NewQuicClientSession(const FunctionCallbackInfo<Value>& args) {
   node::Utf8Value servername(env->isolate(), args[6]);
   std::string hostname(*servername);
 
-  SocketAddress::New(*address, port, family, &remote_addr);
+  if (!SocketAddress::New(family, *address, port, &remote_addr))
+    return args.GetReturnValue().Set(ERR_FAILED_TO_CREATE_SESSION);
 
   if (args[11]->IsString()) {
     Utf8Value val(env->isolate(), args[11]);

--- a/src/quic/node_quic_socket.cc
+++ b/src/quic/node_quic_socket.cc
@@ -1059,7 +1059,7 @@ void QuicSocketListen(const FunctionCallbackInfo<Value>& args) {
             preferred_address_family,
             *preferred_address_host,
             preferred_address_port,
-            &preferred_address_storage) != nullptr) {
+            &preferred_address_storage)) {
       preferred_address =
           reinterpret_cast<const sockaddr*>(&preferred_address_storage);
     }

--- a/src/quic/node_quic_socket.h
+++ b/src/quic/node_quic_socket.h
@@ -205,7 +205,7 @@ class QuicEndpoint : public BaseObject,
       Local<Object> udp_wrap);
 
   const SocketAddress& local_address() const {
-    udp_->GetSockName(&local_address_);
+    local_address_ = udp_->GetSockName();
     return local_address_;
   }
 

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -627,20 +627,12 @@ AsyncWrap* UDPWrap::GetAsyncWrap() {
   return this;
 }
 
-int UDPWrap::GetPeerName(sockaddr* name, int* namelen) {
-  return uv_udp_getpeername(&handle_, name, namelen);
+SocketAddress UDPWrap::GetPeerName() {
+  return SocketAddress::FromPeerName(handle_);
 }
 
-int UDPWrap::GetSockName(sockaddr* name, int* namelen) {
-  return uv_udp_getsockname(&handle_, name, namelen);
-}
-
-SocketAddress* UDPWrap::GetPeerName(SocketAddress* addr) {
-  return SocketAddress::FromPeerName(handle_, addr);
-}
-
-SocketAddress* UDPWrap::GetSockName(SocketAddress* addr) {
-  return SocketAddress::FromSockName(handle_, addr);
+SocketAddress UDPWrap::GetSockName() {
+  return SocketAddress::FromSockName(handle_);
 }
 
 void UDPWrapBase::RecvStart(const FunctionCallbackInfo<Value>& args) {

--- a/src/udp_wrap.h
+++ b/src/udp_wrap.h
@@ -91,15 +91,8 @@ class UDPWrapBase {
                        size_t nbufs,
                        const sockaddr* addr) = 0;
 
-  // Stores the sockaddr for the peer in `name`.
-  virtual int GetPeerName(sockaddr* name, int* namelen) = 0;
-
-  // Stores the sockaddr for the local socket in `name`.
-  virtual int GetSockName(sockaddr* name, int* namelen) = 0;
-
-  virtual SocketAddress* GetPeerName(SocketAddress* addr = nullptr) = 0;
-
-  virtual SocketAddress* GetSockName(SocketAddress* addr = nullptr) = 0;
+  virtual SocketAddress GetPeerName() = 0;
+  virtual SocketAddress GetSockName() = 0;
 
   // Returns an AsyncWrap object with the same lifetime as this object.
   virtual AsyncWrap* GetAsyncWrap() = 0;
@@ -168,10 +161,9 @@ class UDPWrap final : public HandleWrap,
   ssize_t Send(uv_buf_t* bufs,
                size_t nbufs,
                const sockaddr* addr) override;
-  int GetPeerName(sockaddr* name, int* namelen) override;
-  int GetSockName(sockaddr* name, int* namelen) override;
-  SocketAddress* GetPeerName(SocketAddress* addr = nullptr) override;
-  SocketAddress* GetSockName(SocketAddress* addr = nullptr) override;
+
+  SocketAddress GetPeerName() override;
+  SocketAddress GetSockName() override;
 
   AsyncWrap* GetAsyncWrap() override;
 

--- a/test/cctest/test_sockaddr.cc
+++ b/test/cctest/test_sockaddr.cc
@@ -23,8 +23,8 @@ TEST(SocketAddress, SocketAddress) {
   addr.set_flow_label(12345);
   CHECK_EQ(addr.flow_label(), 0);
 
-  CHECK(!SocketAddress::Compare()(addr, addr2));
-  CHECK(SocketAddress::Compare()(addr, addr));
+  CHECK_NE(addr, addr2);
+  CHECK_EQ(addr, addr);
 
   CHECK_EQ(SocketAddress::Hash()(addr), SocketAddress::Hash()(addr));
   CHECK_NE(SocketAddress::Hash()(addr), SocketAddress::Hash()(addr2));


### PR DESCRIPTION
- Remove methods that duplicate functionality for slightly different
  signatures (e.g. taking a pointer vs taking a reference).
- Be more explicit about situations in which only IPv6 and IPv4 are
  supported.
- Use `operator==` for equality comparison.
- Remove unnecessary passing of `SocketAddress*` arguments.
- Othe minor cleanup.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
