### PR TITLE
WTF?

### DIFF
--- a/src/node_options-inl.h
+++ b/src/node_options-inl.h
@@ -207,14 +207,20 @@ template <typename ChildOptions>
 void OptionsParser<Options>::Insert(
     const OptionsParser<ChildOptions>& child_options_parser,
     ChildOptions* (Options::* get_child)()) {
-  aliases_.insert(std::begin(child_options_parser.aliases_),
-                  std::end(child_options_parser.aliases_));
+  if (child_options_parser.aliases_.size() > 0) {
+    aliases_.insert(std::begin(child_options_parser.aliases_),
+                    std::end(child_options_parser.aliases_));
+  }
 
-  for (const auto& pair : child_options_parser.options_)
-    options_.emplace(pair.first, Convert(pair.second, get_child));
+  if (child_options_parser.options_.size() > 0) {
+    for (const auto& pair : child_options_parser.options_)
+      options_.emplace(pair.first, Convert(pair.second, get_child));
+  }
 
-  for (const auto& pair : child_options_parser.implications_)
-    implications_.emplace(pair.first, Convert(pair.second, get_child));
+  if (child_options_parser.implications_.size() > 0) {
+    for (const auto& pair : child_options_parser.implications_)
+      implications_.emplace(pair.first, Convert(pair.second, get_child));
+  }
 }
 
 inline std::string NotAllowedInEnvErr(const std::string& arg) {


### PR DESCRIPTION
After rebasing from nodejs/node, the build on Windows fails with a segfault when running node_mksnapshot... This commit fixes it but it's really not clear why. It's definitely something caused by the quic commit because without that commit the build works. Still trying to track it down. 

/cc @addaleax 