### PR TITLE
quic: cleanup options and add highWaterMark/defaultEncoding

### DIFF
--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -1001,7 +1001,12 @@ added: REPLACEME
 * `options` {Object}
   * `halfOpen` {boolean} Set to `true` to open a unidirectional stream, `false`
     to open a bidirectional stream. **Default**: `true`.
-  * `highWaterMark` {number}
+  * `highWaterMark` {number} Total number of bytes that the `QuicStream` may
+    buffer internally before the `quicstream.write()` function starts returning
+    `false`. Default: `16384`.
+  * `defaultEncoding` {string} The default encoding that is used when no
+    encoding is specified as an argument to `quicstream.write()`. Default:
+    `'utf8'`.
 * Returns: {QuicStream}
 
 Returns a new `QuicStream`.
@@ -1475,6 +1480,9 @@ added: REPLACEME
     client certificate.
   * `crl` {string|string[]|Buffer|Buffer[]} PEM formatted CRLs (Certificate
     Revocation Lists).
+  * `defaultEncoding` {string} The default encoding that is used when no
+    encoding is specified as an argument to `quicstream.write()`. Default:
+    `'utf8'`.
   * `dhparam` {string|Buffer} Diffie Hellman parameters, required for
     [Perfect Forward Secrecy][]. Use `openssl dhparam` to create the parameters.
     The key length must be greater than or equal to 1024 bits, otherwise an
@@ -1488,6 +1496,9 @@ added: REPLACEME
     available curve names. On recent releases, `openssl ecparam -list_curves`
     will also display the name and description of each available elliptic curve.
     **Default:** [`tls.DEFAULT_ECDH_CURVE`][].
+  * `highWaterMark` {number} Total number of bytes that the `QuicStream` may
+    buffer internally before the `quicstream.write()` function starts returning
+    `false`. Default: `16384`.
   * `honorCipherOrder` {boolean} Attempt to use the server's cipher suite
     preferences instead of the client's. When `true`, causes
     `SSL_OP_CIPHER_SERVER_PREFERENCE` to be set in `secureOptions`, see
@@ -1600,8 +1611,8 @@ An array of `QuicEndpoint` instances associated with the `QuicSocket`.
 added: REPLACEME
 -->
 
-* `options` {Object}
-  * `alpn` {string} An ALPN protocol identifier.
+* `options` {Objt}
+  * `alpn` {string} A required ALPN protocol identifier.
   * `ca` {string|string[]|Buffer|Buffer[]} Optionally override the trusted CA
     certificates. Default is to trust the well-known CAs curated by Mozilla.
     Mozilla's CAs are completely replaced when CAs are explicitly specified
@@ -1636,6 +1647,9 @@ added: REPLACEME
     client certificate.
   * `crl` {string|string[]|Buffer|Buffer[]} PEM formatted CRLs (Certificate
     Revocation Lists).
+  * `defaultEncoding` {string} The default encoding that is used when no
+    encoding is specified as an argument to `quicstream.write()`. Default:
+    `'utf8'`.
   * `dhparam` {string|Buffer} Diffie Hellman parameters, required for
     [Perfect Forward Secrecy][]. Use `openssl dhparam` to create the parameters.
     The key length must be greater than or equal to 1024 bits, otherwise an
@@ -1649,8 +1663,11 @@ added: REPLACEME
     available curve names. On recent releases, `openssl ecparam -list_curves`
     will also display the name and description of each available elliptic curve.
     **Default:** [`tls.DEFAULT_ECDH_CURVE`][].
+  * `highWaterMark` {number} Total number of bytes that `QuicStream` instances
+    may buffer internally before the `quicstream.write()` function starts
+    returning `false`. Default: `16384`.
   * `honorCipherOrder` {boolean} Attempt to use the server's cipher suite
-    preferences instead of the client's. When `true`, causes
+    references instead of the client's. When `true`, causes
     `SSL_OP_CIPHER_SERVER_PREFERENCE` to be set in `secureOptions`, see
     [OpenSSL Options][] for more information.
   * `idleTimeout` {number}
@@ -2103,6 +2120,32 @@ added: REPLACEME
 
 This property is `true` if the underlying session is not finished yet,
 i.e. before the `'ready'` event is emitted.
+
+#### quicstream.pushStream(headers\[, options\])
+<!-- YAML
+added: REPLACEME
+-->
+
+* `headers` {Object} An object representing a block of headers to be
+  transmitted with the push promise.
+* `options` {Object}
+  * `highWaterMark` {number} Total number of bytes that the `QuicStream` may
+    buffer internally before the `quicstream.write()` function starts returning
+    `false`. Default: `16384`.
+  * `defaultEncoding` {string} The default encoding that is used when no
+    encoding is specified as an argument to `quicstream.write()`. Default:
+    `'utf8'`.
+
+* Returns: {QuicStream}
+
+If the selected QUIC application protocol supports push streams, then the
+`pushStream()` method will initiate a new push promise and create a new
+unidirectional `QuicStream` object used to fulfill that push.
+
+Currently only HTTP/3 supports the use of `pushStream()`.
+
+If the selected QUIC application protocol does not support push streams, an
+error will be thrown.
 
 #### quicstream.serverInitiated
 <!-- YAML

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -33,7 +33,11 @@ const {
   validateTransportParams,
   validateQuicClientSessionOptions,
   validateQuicSocketOptions,
+  validateQuicStreamOptions,
+  validateQuicSocketListenOptions,
   validateQuicEndpointOptions,
+  validateCreateSecureContextOptions,
+  validateQuicSocketConnectOptions,
 } = require('internal/quic/util');
 const util = require('util');
 const assert = require('internal/assert');
@@ -125,9 +129,6 @@ const {
   constants: {
     AF_INET,
     AF_INET6,
-    NGTCP2_ALPN_H3,
-    NGTCP2_MAX_CIDLEN,
-    NGTCP2_MIN_CIDLEN,
     IDX_QUIC_SESSION_MAX_PACKET_SIZE_DEFAULT,
     IDX_QUIC_SESSION_STATE_MAX_STREAMS_BIDI,
     IDX_QUIC_SESSION_STATE_MAX_STREAMS_UNI,
@@ -205,10 +206,6 @@ const {
   validateString,
 } = require('internal/validators');
 
-const DEFAULT_QUIC_CIPHERS = 'TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:' +
-                             'TLS_CHACHA20_POLY1305_SHA256';
-const DEFAULT_GROUPS = 'P-256:X25519:P-384:P-521';
-
 const emit = EventEmitter.prototype.emit;
 
 const kAddSession = Symbol('kAddSession');
@@ -222,6 +219,7 @@ const kContinueListen = Symbol('kContinueListen');
 const kDestroy = Symbol('kDestroy');
 const kEndpointBound = Symbol('kEndpointBound');
 const kEndpointClose = Symbol('kEndpointClose');
+const kGetStreamOptions = Symbol('kGetStreamOptions');
 const kHandshake = Symbol('kHandshake');
 const kHandshakePost = Symbol('kHandshakePost');
 const kHeaders = Symbol('kHeaders');
@@ -274,7 +272,11 @@ function onSocketServerBusy(on) {
 // Called by the C++ internals when a new server QuicSession has been created.
 function onSessionReady(handle) {
   const socket = this[owner_symbol];
-  const session = new QuicServerSession(socket, handle);
+  const session =
+    new QuicServerSession(
+      socket,
+      handle,
+      socket[kGetStreamOptions]());
   process.nextTick(emit.bind(socket, 'session', session));
 }
 
@@ -520,7 +522,15 @@ function onStreamReady(streamHandle, id, push_id) {
 
   // TODO(@jasnell): Get default options from session
   const uni = id & 0b10;
-  const stream = new QuicStream({ writable: !uni }, session, push_id);
+  const {
+    highWaterMark,
+    defaultEncoding,
+  } = session[kGetStreamOptions]();
+  const stream = new QuicStream({
+    writable: !uni,
+    highWaterMark,
+    defaultEncoding,
+  }, session, push_id);
   stream[kSetHandle](streamHandle);
   if (uni)
     stream.end();
@@ -682,43 +692,11 @@ function connectAfterBind(session, lookup, address, type) {
 // Creates the SecureContext used by QuicSocket instances that are listening
 // for new connections.
 function createSecureContext(options, init_cb) {
-  const {
-    ca,
-    cert,
-    ciphers = DEFAULT_QUIC_CIPHERS,
-    clientCertEngine,
-    crl,
-    dhparam,
-    ecdhCurve,
-    groups = DEFAULT_GROUPS,
-    honorCipherOrder,
-    key,
-    passphrase,
-    pfx,
-    sessionIdContext,
-    secureProtocol
-  } = { ...options };
-
-  validateString(ciphers, 'option.ciphers');
-  validateString(groups, 'option.groups');
-
-  const sc = _createSecureContext({
-    secureProtocol,
-    ca,
-    cert,
-    ciphers: ciphers || DEFAULT_QUIC_CIPHERS,
-    clientCertEngine,
-    crl,
-    dhparam,
-    ecdhCurve,
-    honorCipherOrder,
-    key,
-    passphrase,
-    pfx,
-    sessionIdContext
-  });
-  // Perform additional QUIC specific initialization on the SecureContext
-  init_cb(sc.context, groups || DEFAULT_GROUPS);
+  const sc_options = validateCreateSecureContextOptions(options);
+  const { groups } = sc_options;
+  const sc = _createSecureContext(sc_options);
+  // TODO(@jasnell): Determine if it's really necessary to pass in groups here.
+  init_cb(sc.context, groups);
   return sc;
 }
 
@@ -946,6 +924,8 @@ class QuicSocket extends EventEmitter {
   #serverBusy = false;
   #serverListening = false;
   #serverSecureContext = undefined;
+  #highWaterMark = undefined;
+  #defaultEncoding = undefined;
   #sessions = new Set();
   #state = kSocketUnbound;
   #stats = undefined;
@@ -1026,6 +1006,13 @@ class QuicSocket extends EventEmitter {
       ...endpoint,
       preferred: true
     });
+  }
+
+  [kGetStreamOptions]() {
+    return {
+      highWaterMark: this.#highWaterMark,
+      defaultEncoding: this.#defaultEncoding,
+    };
   }
 
   [kSetHandle](handle) {
@@ -1119,14 +1106,6 @@ class QuicSocket extends EventEmitter {
   // on('session') event. Errors may be thrown synchronously by this
   // function.
   listen(options, callback) {
-    if (typeof options === 'function') {
-      callback = options;
-      options = {};
-    }
-
-    if (callback != null && typeof callback !== 'function')
-      throw new ERR_INVALID_CALLBACK(callback);
-
     if (this.#serverListening)
       throw new ERR_QUICSOCKET_LISTENING();
 
@@ -1134,6 +1113,14 @@ class QuicSocket extends EventEmitter {
         this.#state === kSocketClosing) {
       throw new ERR_QUICSOCKET_DESTROYED('listen');
     }
+
+    if (typeof options === 'function') {
+      callback = options;
+      options = {};
+    }
+
+    if (callback !== undefined && typeof callback !== 'function')
+      throw new ERR_INVALID_CALLBACK(callback);
 
     options = {
       secureProtocol: 'TLSv1_3_server_method',
@@ -1143,22 +1130,11 @@ class QuicSocket extends EventEmitter {
 
     // The ALPN protocol identifier is strictly required.
     const {
-      alpn = NGTCP2_ALPN_H3,
-      rejectUnauthorized,
-      requestCert,
-    } = options;
-
-    validateString(alpn, 'options.alpn');
-
-    validateBoolean(
-      rejectUnauthorized,
-      'options.rejectUnauthorized',
-      { allowUndefined: true });
-
-    validateBoolean(
-      requestCert,
-      'options.requestCert',
-      { allowUndefined: true });
+      alpn,
+      transportParams,
+      highWaterMark,
+      defaultEncoding,
+    } = validateQuicSocketListenOptions(options);
 
     // Store the secure context so that it is not garbage collected
     // while we still need to make use of it.
@@ -1166,16 +1142,13 @@ class QuicSocket extends EventEmitter {
     // since we do not need to access this anywhere else.
     // The secure context options will be validated. Keep this before the
     // kMaybeBind call below.
-    const transportParams =
-      validateTransportParams(
-        options,
-        NGTCP2_MAX_CIDLEN,
-        NGTCP2_MIN_CIDLEN);
     this.#serverSecureContext =
       createSecureContext(
         options,
         initSecureContext);
 
+    this.#highWaterMark = highWaterMark;
+    this.#defaultEncoding = defaultEncoding;
     this.#serverListening = true;
     this.#alpn = alpn;
 
@@ -1215,9 +1188,9 @@ class QuicSocket extends EventEmitter {
     };
 
     const {
-      type = 'udp4',
+      type,
       address,
-    } = options;
+    } = validateQuicSocketConnectOptions(options);
 
     if (this.#state === kSocketDestroyed ||
         this.#state === kSocketClosing) {
@@ -1236,7 +1209,7 @@ class QuicSocket extends EventEmitter {
       session,
       this.#lookup,
       address,
-      getSocketType(type)));
+      type));
 
     return session;
   }
@@ -1574,8 +1547,16 @@ class QuicSession extends EventEmitter {
   #verifyErrorCode = undefined;
   #handshakeAckHistogram = undefined;
   #handshakeContinuationHistogram = undefined;
+  #highWaterMark = undefined;
+  #defaultEncoding = undefined;
 
-  constructor(socket, servername, alpn) {
+  constructor(socket, options) {
+    const {
+      alpn,
+      servername,
+      highWaterMark,
+      defaultEncoding,
+    } = options;
     super({ captureRejections: true });
     this.on('newListener', onNewListener);
     this.on('removeListener', onRemoveListener);
@@ -1583,6 +1564,15 @@ class QuicSession extends EventEmitter {
     socket[kAddSession](this);
     this.#servername = servername;
     this.#alpn = alpn;
+    this.#highWaterMark = highWaterMark;
+    this.#defaultEncoding = defaultEncoding;
+  }
+
+  [kGetStreamOptions]() {
+    return {
+      highWaterMark: this.#highWaterMark,
+      defaultEncoding: this.#defaultEncoding,
+    };
   }
 
   [kSetHandle](handle) {
@@ -1958,23 +1948,25 @@ class QuicSession extends EventEmitter {
     if (this.#destroyed || this.#closing)
       throw new ERR_QUICSESSION_DESTROYED('openStream');
     const {
-      halfOpen = false,
+      halfOpen,  // Unidirectional or Bidirectional
       highWaterMark,
-    } = { ...options };
+      defaultEncoding,
+    } = validateQuicStreamOptions(options);
 
-    validateBoolean(halfOpen, 'options.halfOpen', { allowUndefined: true });
+    const stream = new QuicStream({
+      highWaterMark,
+      defaultEncoding,
+      readable: !halfOpen
+    }, this);
 
-    const stream = new QuicStream(
-      {
-        highWaterMark,
-        readable: !halfOpen
-      },
-      this);
+    // TODO(@jasnell): This really shouldn't be necessary
     if (halfOpen) {
       stream.push(null);
       stream.read();
     }
 
+    // TODO(@jasnell): Once we've verified that 0RTT is working, then it should
+    // be possible to create the underlying stream before handshake completes.
     if (!this.#handshakeComplete)
       this.once('secure', QuicSession.#makeStream.bind(this, stream, halfOpen));
     else
@@ -2103,8 +2095,12 @@ class QuicSession extends EventEmitter {
 class QuicServerSession extends QuicSession {
   #contexts = [];
 
-  constructor(socket, handle) {
-    super(socket);
+  constructor(socket, handle, options) {
+    const {
+      highWaterMark,
+      defaultEncoding,
+    } = options;
+    super(socket, { highWaterMark, defaultEncoding });
     this[kSetHandle](handle);
   }
 
@@ -2210,6 +2206,8 @@ class QuicClientSession extends QuicSession {
       sessionTicket,
       verifyHostnameIdentity,
       qlog,
+      highWaterMark,
+      defaultEncoding,
     } = validateQuicClientSessionOptions(options);
 
     if (!verifyHostnameIdentity && !warnedVerifyHostnameIdentity) {
@@ -2221,7 +2219,7 @@ class QuicClientSession extends QuicSession {
       );
     }
 
-    super(socket, servername, alpn);
+    super(socket, { servername, alpn, highWaterMark, defaultEncoding });
     this.#dcid = dcid;
     this.#ipv6Only = ipv6Only;
     this.#minDHSize = minDHSize;
@@ -2382,8 +2380,10 @@ function streamOnPause() {
 class QuicStream extends Duplex {
   #closed = false;
   #aborted = false;
+  #defaultEncoding = undefined;
   #didRead = false;
   #id = undefined;
+  #highWaterMark = undefined;
   #push_id = undefined;
   #resetCode = undefined;
   #session = undefined;
@@ -2393,13 +2393,20 @@ class QuicStream extends Duplex {
   #stats = undefined;
 
   constructor(options, session, push_id) {
+    const {
+      highWaterMark,
+      defaultEncoding,
+    } = options;
     super({
-      ...options,
+      highWaterMark,
+      defaultEncoding,
       allowHalfOpen: true,
       decodeStrings: true,
       emitClose: true,
       autoDestroy: false,
     });
+    this.#highWaterMark = highWaterMark;
+    this.#defaultEncoding = defaultEncoding;
     this.#session = session;
     this.#push_id = push_id;
     this._readableState.readingMore = true;
@@ -2784,24 +2791,53 @@ class QuicStream extends Duplex {
     return this.#dataAckHistogram;
   }
 
-  pushStream(headers = {}) {
+  pushStream(headers = {}, options = {}) {
     if (this.destroyed)
       throw new ERR_QUICSTREAM_DESTROYED('push');
 
+    const {
+      highWaterMark = this.#highWaterMark,
+      defaultEncoding = this.#defaultEncoding,
+    } = validateQuicStreamOptions(options);
+
     validateObject(headers, 'headers');
 
+    // Push streams are only supported on QUIC servers, and
+    // only if the original stream is bidirectional.
+    // TODO(@jasnell): This is really an http/3 specific
+    // requirement so if we end up later with another
+    // QUIC application protocol that has a similar
+    // notion of push streams without this restriction,
+    // then we'll need to check alpn value here also.
     if (!this.clientInitiated && !this.bidirectional)
       throw new ERR_QUICSTREAM_INVALID_PUSH();
 
+    // TODO(@jasnell): The assertValidPseudoHeader validator
+    // here is HTTP/3 specific. If we end up with another
+    // QUIC application protocol that supports push streams,
+    // we will need to select a validator based on the
+    // alpn value.
     const handle = this[kHandle].submitPush(
       mapToHeaders(headers, assertValidPseudoHeader));
 
+    // If undefined is returned, it either means that push
+    // streams are not supported by the underlying application,
+    // or push streams are currently disabled/blocked. This
+    // will typically be the case with HTTP/3 when the client
+    // peer has disabled push.
     if (handle === undefined)
       throw new ERR_QUICSTREAM_UNSUPPORTED_PUSH();
 
-    const stream = new QuicStream({ readable: false }, this.session);
+    const stream = new QuicStream({
+      readable: false,
+      highWaterMark,
+      defaultEncoding,
+    }, this.session);
+
+    // TODO(@jasnell): The null push and subsequent read shouldn't be necessary
     stream.push(null);
     stream.read();
+
     stream[kSetHandle](handle);
     this.session[kAddStream](stream.id, stream);
     return stream;

--- a/lib/internal/quic/util.js
+++ b/lib/internal/quic/util.js
@@ -9,7 +9,6 @@ const {
   },
 } = require('internal/errors');
 
-const { Buffer } = require('buffer');
 const {
   isLegalPort,
   isIP,
@@ -20,12 +19,15 @@ const {
   getAllowUnauthorized,
 } = require('internal/options');
 
+const { Buffer } = require('buffer');
+
 const {
   sessionConfig,
   http3Config,
   constants: {
     AF_INET,
     AF_INET6,
+    NGTCP2_ALPN_H3,
     DEFAULT_RETRYTOKEN_EXPIRATION,
     DEFAULT_MAX_CONNECTIONS,
     DEFAULT_MAX_CONNECTIONS_PER_HOST,
@@ -72,6 +74,10 @@ const {
   validateObject,
   validateString,
 } = require('internal/validators');
+
+const kDefaultQuicCiphers = 'TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:' +
+                            'TLS_CHACHA20_POLY1305_SHA256';
+const kDefaultGroups = 'P-256:X25519:P-384:P-521';
 
 let dns;
 
@@ -274,6 +280,8 @@ function validateQuicClientSessionOptions(options = {}) {
     sessionTicket,
     verifyHostnameIdentity = true,
     qlog = false,
+    highWaterMark,
+    defaultEncoding,
   } = options;
 
   validateNumber(minDHSize, 'options.minDHSize');
@@ -348,6 +356,32 @@ function validateQuicClientSessionOptions(options = {}) {
     sessionTicket,
     verifyHostnameIdentity,
     qlog,
+    ...validateQuicStreamOptions({ highWaterMark, defaultEncoding })
+  };
+}
+
+function validateQuicStreamOptions(options = {}) {
+  validateObject(options);
+  const {
+    defaultEncoding = 'utf8',
+    halfOpen,
+    highWaterMark,
+  } = options;
+  if (!Buffer.isEncoding(defaultEncoding)) {
+    throw new ERR_INVALID_ARG_VALUE(
+      'options.defaultEncoding',
+      defaultEncoding,
+      'is not a valid encoding');
+  }
+  validateBoolean(halfOpen, 'options.halfOpen', { allowUndefined: true });
+  validateInteger(highWaterMark, 'options.highWaterMark', {
+    min: 0,
+    allowUndefined: true
+  });
+  return {
+    defaultEncoding,
+    halfOpen,
+    highWaterMark,
   };
 }
 
@@ -457,6 +491,93 @@ function validateQuicSocketOptions(options = {}) {
     qlog,
     statelessResetSecret,
     disableStatelessReset,
+  };
+}
+
+function validateQuicSocketListenOptions(options = {}) {
+  validateObject(options);
+  const {
+    alpn = NGTCP2_ALPN_H3,
+    rejectUnauthorized,
+    requestCert,
+    highWaterMark,
+    defaultEncoding,
+  } = options;
+  validateString(alpn, 'options.alpn');
+  validateBoolean(
+    rejectUnauthorized,
+    'options.rejectUnauthorized',
+    { allowUndefined: true });
+  validateBoolean(
+    requestCert,
+    'options.requestCert',
+    { allowUndefined: true });
+
+  const transportParams =
+    validateTransportParams(
+      options,
+      NGTCP2_MAX_CIDLEN,
+      NGTCP2_MIN_CIDLEN);
+
+  return {
+    alpn,
+    rejectUnauthorized,
+    requestCert,
+    transportParams,
+    ...validateQuicStreamOptions({ highWaterMark, defaultEncoding })
+  };
+}
+
+function validateQuicSocketConnectOptions(options = {}) {
+  validateObject(options);
+  const {
+    type = 'udp4',
+    address,
+  } = options;
+  validateString(address, 'options.address', { allowUndefined: true });
+  return {
+    type: getSocketType(type),
+    address,
+  };
+}
+
+function validateCreateSecureContextOptions(options = {}) {
+  validateObject(options);
+  const {
+    ca,
+    cert,
+    ciphers = kDefaultQuicCiphers,
+    clientCertEngine,
+    crl,
+    dhparam,
+    ecdhCurve,
+    groups = kDefaultGroups,
+    honorCipherOrder,
+    key,
+    passphrase,
+    pfx,
+    sessionIdContext,
+    secureProtocol
+  } = options;
+  validateString(ciphers, 'option.ciphers');
+  validateString(groups, 'option.groups');
+  // Additional validation occurs within the tls
+  // createSecureContext function.
+  return {
+    ca,
+    cert,
+    ciphers,
+    clientCertEngine,
+    crl,
+    dhparam,
+    ecdhCurve,
+    groups,
+    honorCipherOrder,
+    key,
+    passphrase,
+    pfx,
+    sessionIdContext,
+    secureProtocol
   };
 }
 
@@ -589,5 +710,9 @@ module.exports = {
   validateTransportParams,
   validateQuicClientSessionOptions,
   validateQuicSocketOptions,
+  validateQuicStreamOptions,
+  validateQuicSocketListenOptions,
   validateQuicEndpointOptions,
+  validateCreateSecureContextOptions,
+  validateQuicSocketConnectOptions,
 };

--- a/test/parallel/test-quic-errors-quicsocket-connect.js
+++ b/test/parallel/test-quic-errors-quicsocket-connect.js
@@ -106,6 +106,7 @@ const client = createSocket();
   'maxStreamDataUni',
   'maxStreamsBidi',
   'maxStreamsUni',
+  'highWaterMark',
 ].forEach((prop) => {
   assert.throws(() => client.connect({ [prop]: -1 }), {
     code: 'ERR_OUT_OF_RANGE'
@@ -182,6 +183,13 @@ const client = createSocket();
     });
   });
 });
+
+['', 1n, {}, [], false, 'zebra'].forEach((defaultEncoding) => {
+  assert.throws(() => client.connect({ defaultEncoding }), {
+    code: 'ERR_INVALID_ARG_VALUE'
+  });
+});
+
 
 // Test that connect cannot be called after QuicSocket is closed.
 client.close();

--- a/test/parallel/test-quic-errors-quicsocket-listen.js
+++ b/test/parallel/test-quic-errors-quicsocket-listen.js
@@ -61,6 +61,7 @@ const { createSocket } = require('quic');
     'maxStreamDataUni',
     'maxStreamsBidi',
     'maxStreamsUni',
+    'highWaterMark',
   ].forEach((prop) => {
     assert.throws(() => server.listen({ [prop]: -1 }), {
       code: 'ERR_OUT_OF_RANGE'
@@ -80,6 +81,12 @@ const { createSocket } = require('quic');
 
   [1, 1n, 'test', {}, []].forEach((rejectUnauthorized) => {
     assert.throws(() => server.listen({ rejectUnauthorized }), {
+      code: 'ERR_INVALID_ARG_TYPE'
+    });
+  });
+
+  [1, 1n, 'test', {}, []].forEach((requestCert) => {
+    assert.throws(() => server.listen({ requestCert }), {
       code: 'ERR_INVALID_ARG_TYPE'
     });
   });
@@ -126,6 +133,11 @@ const { createSocket } = require('quic');
     });
   });
 
+  ['', 1n, {}, [], false, 'zebra'].forEach((defaultEncoding) => {
+    assert.throws(() => server.listen({ defaultEncoding }), {
+      code: 'ERR_INVALID_ARG_VALUE'
+    });
+  });
 
   // Make sure that after all of the validation checks, the socket
   // is not actually marked as listening at all.

--- a/test/parallel/test-quic-http3-push.js
+++ b/test/parallel/test-quic-http3-push.js
@@ -30,6 +30,22 @@ server.on('session', common.mustCall((session) => {
   session.on('stream', common.mustCall((stream) => {
     assert(stream.submitInitialHeaders({ ':status': '200' }));
 
+    [-1, Number.MAX_SAFE_INTEGER + 1].forEach((highWaterMark) => {
+      assert.throws(() => stream.pushStream({}, { highWaterMark }), {
+        code: 'ERR_OUT_OF_RANGE'
+      });
+    });
+    ['', 1n, {}, [], false].forEach((highWaterMark) => {
+      assert.throws(() => stream.pushStream({}, { highWaterMark }), {
+        code: 'ERR_INVALID_ARG_TYPE'
+      });
+    });
+    ['', 1, 1n, true, [], {}, 'zebra'].forEach((defaultEncoding) => {
+      assert.throws(() => stream.pushStream({}, { defaultEncoding }), {
+        code: 'ERR_INVALID_ARG_VALUE'
+      });
+    });
+
     const push = stream.pushStream({
       ':method': 'GET',
       ':scheme': 'https',


### PR DESCRIPTION
Allow passing in highWaterMark and defaultEncoding options
when creating new `QuicStream` instances using `openStream()`
and `pushStream()`, and allow setting the options for all
newly received peer-initiated `QuicStream` instances.

Additional cleanups and doc nits
