### PR TITLE
quic: configurable max early data

### DIFF
--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -842,18 +842,6 @@ added: REPLACEME
 
 A `BigInt` representing the length of time the `QuicSession` was active.
 
-#### quicsession.earlyData
-<!-- YAML
-added: REPLACEME
--->
-
-* Type: {boolean}
-
-On server `QuicSession` instances, set to `true` on completion of the TLS
-handshake if early data is enabled. On client `QuicSession` instances,
-set to true on handshake completion if early data is enabled *and* was
-accepted by the server.
-
 #### quicsession.getCertificate()
 <!-- YAML
 added: REPLACEME
@@ -1130,6 +1118,18 @@ Initiates QuicSession key update.
 
 An error will be thrown if called before `quicsession.handshakeConfirmed`
 is equal to `true`.
+
+#### quicsession.usingEarlyData
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {boolean}
+
+On server `QuicSession` instances, set to `true` on completion of the TLS
+handshake if early data is enabled. On client `QuicSession` instances,
+set to true on handshake completion if early data is enabled *and* was
+accepted by the server.
 
 ### Class: QuicClientSession extends QuicSession
 <!-- YAML

--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -842,6 +842,18 @@ added: REPLACEME
 
 A `BigInt` representing the length of time the `QuicSession` was active.
 
+#### quicsession.earlyData
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {boolean}
+
+On server `QuicSession` instances, set to `true` on completion of the TLS
+handshake if early data is enabled. On client `QuicSession` instances,
+set to true on handshake completion if early data is enabled *and* was
+accepted by the server.
+
 #### quicsession.getCertificate()
 <!-- YAML
 added: REPLACEME
@@ -1153,9 +1165,8 @@ added: REPLACEME
 
 The `'sessionTicket'` event is emitted when a new TLS session ticket has been
 generated for the current `QuicClientSession`. The callback is invoked with
-three arguments:
+two arguments:
 
-* `sessionID` {Buffer} The serialized session ticket identifier.
 * `sessionTicket` {Buffer} The serialized session ticket.
 * `remoteTransportParams` {Buffer} The serialized remote transport parameters
   provided by the QUIC server.
@@ -1656,6 +1667,8 @@ added: REPLACEME
     error will be thrown. It is strongly recommended to use 2048 bits or larger
     for stronger security. If omitted or invalid, the parameters are silently
     discarded and DHE ciphers will not be available.
+  * `earlyData` {boolean} Set to `false` to disable 0RTT early data.
+    Default: `true`.
   * `ecdhCurve` {string} A string describing a named curve or a colon separated
     list of curve NIDs or names, for example `P-521:P-384:P-256`, to use for
     ECDH key agreement. Set to `auto` to select the

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -215,7 +215,6 @@ const kCert = Symbol('kCert');
 const kClientHello = Symbol('kClientHello');
 const kContinueBind = Symbol('kContinueBind');
 const kContinueConnect = Symbol('kContinueConnect');
-const kContinueListen = Symbol('kContinueListen');
 const kDestroy = Symbol('kDestroy');
 const kEndpointBound = Symbol('kEndpointBound');
 const kEndpointClose = Symbol('kEndpointClose');
@@ -223,10 +222,8 @@ const kGetStreamOptions = Symbol('kGetStreamOptions');
 const kHandshake = Symbol('kHandshake');
 const kHandshakePost = Symbol('kHandshakePost');
 const kHeaders = Symbol('kHeaders');
-const kInit = Symbol('kInit');
 const kMaybeBind = Symbol('kMaybeBind');
-const kMaybeReady = Symbol('kMaybeReady');
-const kReady = Symbol('kReady');
+const kSocketReady = Symbol('kSocketReady');
 const kRemoveSession = Symbol('kRemove');
 const kRemoveStream = Symbol('kRemoveStream');
 const kServerBusy = Symbol('kServerBusy');
@@ -238,7 +235,6 @@ const kTrackWriteState = Symbol('kTrackWriteState');
 const kUDPHandleForTesting = Symbol('kUDPHandleForTesting');
 const kUsePreferredAddress = Symbol('kUsePreferredAddress');
 const kVersionNegotiation = Symbol('kVersionNegotiation');
-const kWriteGeneric = Symbol('kWriteGeneric');
 
 const kSocketUnbound = 0;
 const kSocketPending = 1;
@@ -247,6 +243,7 @@ const kSocketClosing = 3;
 const kSocketDestroyed = 4;
 
 let diagnosticPacketLossWarned = false;
+let warnedVerifyHostnameIdentity = false;
 
 // Called by the C++ internals when the socket is closed.
 // When this is called, the only thing left to do is destroy
@@ -396,7 +393,8 @@ function onSessionHandshake(
   cipherVersion,
   maxPacketLength,
   verifyErrorReason,
-  verifyErrorCode) {
+  verifyErrorCode,
+  earlyData) {
   this[owner_symbol][kHandshake](
     servername,
     alpn,
@@ -404,20 +402,20 @@ function onSessionHandshake(
     cipherVersion,
     maxPacketLength,
     verifyErrorReason,
-    verifyErrorCode);
+    verifyErrorCode,
+    earlyData);
 }
 
 // Called by the C++ internals when TLS session ticket data is
 // available. This is generally most useful on the client side
 // where the session ticket needs to be persisted for session
 // resumption and 0RTT.
-function onSessionTicket(sessionID, sessionTicket, transportParams) {
+function onSessionTicket(sessionTicket, transportParams) {
   if (this[owner_symbol]) {
     process.nextTick(
       emit.bind(
         this[owner_symbol],
         'sessionTicket',
-        sessionID,
         sessionTicket,
         transportParams));
   }
@@ -604,19 +602,6 @@ setCallbacks({
   onStreamBlocked,
 });
 
-// afterLookup is invoked when binding a QuicEndpoint. The first
-// step to binding is to resolve the given hostname into an ip
-// address. Once resolution is complete, the ip address needs to
-// be passed on to the [kContinueBind] function or the QuicEndpoint
-// needs to be destroyed.
-function afterLookup(err, ip) {
-  if (err) {
-    this.destroy(err);
-    return;
-  }
-  this[kContinueBind](ip);
-}
-
 // connectAfterLookup is invoked when the QuicSocket connect()
 // method has been invoked. The first step is to resolve the given
 // remote hostname into an ip address. Once resolution is complete,
@@ -630,73 +615,14 @@ function connectAfterLookup(type, err, ip) {
   this[kContinueConnect](type, ip);
 }
 
-// Used only from within the continueListen function. When a preferred address
-// has been provided, the hostname given must be resolved into an IP address,
-// which must be passed on to [kContinueListen] or the QuicSocket needs to be
-// destroyed.
-function afterPreferredAddressLookup(
-  transportParams,
-  port,
-  type,
-  err,
-  address) {
-  if (err) {
-    this.destroy(err);
-    return;
-  }
-  this[kContinueListen](transportParams, { address, port, type });
-}
-
-// When the QuicSocket listen() function is called, the first step is to bind
-// the underlying QuicEndpoint's. Once at least one endpoint has been bound,
-// the continueListen function is invoked to continue the process of starting
-// to listen.
-//
-// The preferredAddress is a preferred network endpoint that the server wishes
-// connecting clients to use. If specified, this will be communicate to the
-// client as part of the tranport parameters exchanged during the TLS handshake.
-function continueListen(transportParams, lookup) {
-  const { preferredAddress } = transportParams;
-
-  if (preferredAddress && typeof preferredAddress === 'object') {
-    const {
-      address,
-      port,
-      type = 'udp4',
-    } = { ...preferredAddress };
-    const typeVal = getSocketType(type);
-    // If preferred address is set, we need to perform a lookup on it
-    // to get the IP address. Only after that lookup completes can we
-    // continue with the listen operation, passing in the resolved
-    // preferred address.
-    lookup(
-      address || (typeVal === AF_INET6 ? '::' : '0.0.0.0'),
-      afterPreferredAddressLookup.bind(this, transportParams, port, typeVal));
-    return;
-  }
-  // If preferred address is not set, we can skip directly to the listen
-  this[kContinueListen](transportParams);
-}
-
-// When the QuicSocket connect() function is called, the first step is to bind
-// the underlying QuicEndpoint's. Once at least one endpoint has been bound,
-// the connectAfterBind function is invoked to continue the connection process.
-//
-// The immediate next step is to resolve the address into an ip address.
-function connectAfterBind(session, lookup, address, type) {
-  lookup(
-    address || (type === AF_INET6 ? '::' : '0.0.0.0'),
-    connectAfterLookup.bind(session, type));
-}
-
 // Creates the SecureContext used by QuicSocket instances that are listening
 // for new connections.
 function createSecureContext(options, init_cb) {
   const sc_options = validateCreateSecureContextOptions(options);
-  const { groups } = sc_options;
+  const { groups, earlyData } = sc_options;
   const sc = _createSecureContext(sc_options);
   // TODO(@jasnell): Determine if it's really necessary to pass in groups here.
-  init_cb(sc.context, groups);
+  init_cb(sc.context, groups, earlyData);
   return sc;
 }
 
@@ -708,10 +634,12 @@ function onRemoveListener(event) {
   toggleListeners(this[kHandle], event, false);
 }
 
-// QuicEndpoint wraps a UDP socket.
+// QuicEndpoint wraps a UDP socket and is owned
+// by a QuicSocket. It does not exist independently
+// of the QuicSocket.
 class QuicEndpoint {
-  #socket = undefined;
   #state = kSocketUnbound;
+  #socket = undefined;
   #udpSocket = undefined;
   #address = undefined;
   #ipv6Only = undefined;
@@ -726,7 +654,7 @@ class QuicEndpoint {
       address,
       ipv6Only,
       lookup,
-      port,
+      port = 0,
       reuseAddr,
       type,
       preferred,
@@ -738,6 +666,10 @@ class QuicEndpoint {
     this.#port = port;
     this.#reuseAddr = !!reuseAddr;
     this.#udpSocket = dgram.createSocket(type === AF_INET6 ? 'udp6' : 'udp4');
+
+    // kUDPHandleForTesting is only used in the Node.js test suite to
+    // artificially test the endpoint. This code path should never be
+    // used in user code.
     if (typeof options[kUDPHandleForTesting] === 'object') {
       this.#udpSocket.bind(options[kUDPHandleForTesting]);
       this.#state = kSocketBound;
@@ -759,28 +691,55 @@ class QuicEndpoint {
     return `QuicEndpoint ${util.format(obj)}`;
   }
 
+  // afterLookup is invoked when binding a QuicEndpoint. The first
+  // step to binding is to resolve the given hostname into an ip
+  // address. Once resolution is complete, the ip address needs to
+  // be passed on to the [kContinueBind] function or the QuicEndpoint
+  // needs to be destroyed.
+  static #afterLookup = function(err, ip) {
+    if (err) {
+      this.destroy(err);
+      return;
+    }
+    this[kContinueBind](ip);
+  };
+
+  // kMaybeBind binds the endpoint on-demand if it is not already
+  // bound. If it is bound, we return immediately, otherwise put
+  // the endpoint into the pending state and initiate the binding
+  // process by calling the lookup to resolve the IP address.
   [kMaybeBind]() {
     if (this.#state !== kSocketUnbound)
       return;
     this.#state = kSocketPending;
-    this.#lookup(this.#address, afterLookup.bind(this));
+    this.#lookup(this.#address, QuicEndpoint.#afterLookup.bind(this));
   }
 
+  // IP address resolution is completed and we're ready to finish
+  // binding to the local port.
   [kContinueBind](ip) {
+    const udpHandle = this.#udpSocket[internalDgram.kStateSymbol].handle;
+    if (udpHandle == null) {
+      // TODO(@jasnell): We may need to throw an error here. Under
+      // what conditions does this happen?
+      return;
+    }
     const flags =
       (this.#reuseAddr ? UV_UDP_REUSEADDR : 0) |
       (this.#ipv6Only ? UV_UDP_IPV6ONLY : 0);
-    const udpHandle = this.#udpSocket[internalDgram.kStateSymbol].handle;
-    if (udpHandle == null)
-      return;
-    const ret = udpHandle.bind(ip, this.#port || 0, flags);
+
+    const ret = udpHandle.bind(ip, this.#port, flags);
     if (ret) {
       this.destroy(exceptionWithHostPort(ret, 'bind', ip, this.#port || 0));
       return;
     }
 
-    this.#state = kSocketBound;
+    // On Windows, the fd will be meaningless, but we always record it.
     this.#fd = udpHandle.fd;
+    this.#state = kSocketBound;
+
+    // Notify the owning socket that the QuicEndpoint has been successfully
+    // bound to the local UDP port.
     this.#socket[kEndpointBound](this);
   }
 
@@ -799,39 +758,43 @@ class QuicEndpoint {
     }
   }
 
+  // If the QuicEndpoint is bound, returns an object detailing
+  // the local IP address, port, and address type to which it
+  // is bound. Otherwise, returns an empty object.
   get address() {
-    const out = {};
     if (this.#state !== kSocketDestroyed) {
       try {
         return this.#udpSocket.address();
       } catch (err) {
         if (err.code === 'EBADF') {
           // If there is an EBADF error, the socket is not bound.
-          // Return empty object
+          // Return empty object. Else, rethrow the error because
+          // something else bad happened.
           return {};
         }
         throw err;
       }
     }
-    return out;
+    return {};
   }
 
   get fd() {
     return this.#fd;
   }
 
-  get closing() {
-    return this.#state === kSocketClosing;
-  }
-
+  // True if the QuicEndpoint has been destroyed and is
+  // no longer usable.
   get destroyed() {
     return this.#state === kSocketDestroyed;
   }
 
+  // True if binding has been initiated and is in progress.
   get pending() {
     return this.#state === kSocketPending;
   }
 
+  // True if the QuicEndpoint has been bound to the local
+  // UDP port.
   get bound() {
     return this.#state === kSocketBound;
   }
@@ -918,14 +881,14 @@ class QuicSocket extends EventEmitter {
   #alpn = undefined;
   #autoClose = undefined;
   #client = undefined;
+  #defaultEncoding = undefined;
   #endpoints = new Set();
+  #highWaterMark = undefined;
   #lookup = undefined;
   #server = undefined;
   #serverBusy = false;
   #serverListening = false;
   #serverSecureContext = undefined;
-  #highWaterMark = undefined;
-  #defaultEncoding = undefined;
   #sessions = new Set();
   #state = kSocketUnbound;
   #stats = undefined;
@@ -979,10 +942,12 @@ class QuicSocket extends EventEmitter {
       disableStatelessReset,
     } = validateQuicSocketOptions(options);
     super({ captureRejections: true });
+
     this.#autoClose = autoClose;
     this.#client = client;
     this.#lookup = lookup || (type === AF_INET6 ? lookup6 : lookup4);
     this.#server = server;
+
     const socketOptions =
       (validateAddress ? QUICSOCKET_OPTIONS_VALIDATE_ADDRESS : 0) |
       (validateAddressLRU ? QUICSOCKET_OPTIONS_VALIDATE_ADDRESS_LRU : 0);
@@ -1008,6 +973,9 @@ class QuicSocket extends EventEmitter {
     });
   }
 
+  // Returns the default QuicStream options for peer-initiated
+  // streams. These are passed on to new client and server
+  // QuicSession instances when they are created.
   [kGetStreamOptions]() {
     return {
       highWaterMark: this.#highWaterMark,
@@ -1017,7 +985,7 @@ class QuicSocket extends EventEmitter {
 
   [kSetHandle](handle) {
     this[kHandle] = handle;
-    if (handle) {
+    if (handle !== undefined) {
       handle[owner_symbol] = this;
       this[async_id_symbol] = handle.getAsyncId();
     }
@@ -1037,11 +1005,10 @@ class QuicSocket extends EventEmitter {
 
   [kRemoveSession](session) {
     this.#sessions.delete(session);
-    if (this.closing)
-      this[kMaybeDestroy]();
+    this[kMaybeDestroy]();
   }
 
-  // Bind the UDP socket on demand, only if it hasn't already been bound.
+  // Bind all QuicEndpoints on-demand, only if they haven't already been bound.
   // Function is a non-op if the socket is already bound or in the process of
   // being bound, and will call the callback once the socket is ready.
   [kMaybeBind](callback = () => {}) {
@@ -1049,29 +1016,132 @@ class QuicSocket extends EventEmitter {
       return process.nextTick(callback);
 
     this.once('ready', callback);
+
     if (this.#state === kSocketPending)
       return;
-
     this.#state = kSocketPending;
+
     for (const endpoint of this.#endpoints)
       endpoint[kMaybeBind]();
   }
 
-  // The kContinueListen function is called after all of the necessary
+  [kEndpointBound](endpoint) {
+    if (this.#state === kSocketBound)
+      return;
+    this.#state = kSocketBound;
+
+    // Once the QuicSocket has been bound, we notify all currently
+    // existing QuicSessions. QuicSessions created after this
+    // point will automatically be notified that the QuicSocket
+    // is ready.
+    for (const session of this.#sessions)
+      session[kSocketReady]();
+
+    // The ready event indicates that the QuicSocket is ready to be
+    // used to either listen or connect. No QuicServerSession should
+    // exist before this event, and all QuicClientSession will remain
+    // in Initial states until ready is invoked.
+    process.nextTick(emit.bind(this, 'ready'));
+  }
+
+  // Called when a QuicEndpoint closes
+  [kEndpointClose](endpoint, error) {
+    this.#endpoints.delete(endpoint);
+    process.nextTick(emit.bind(this, 'endpointClose', endpoint, error));
+
+    // If there are no more QuicEndpoints, the QuicSocket is no
+    // longer usable.
+    if (this.#endpoints.size === 0) {
+      // Ensure that there are absolutely no additional sessions
+      for (const session of this.#sessions)
+        session.destroy(error);
+
+      if (error) process.nextTick(emit.bind(this, 'error', error));
+      process.nextTick(emit.bind(this, 'close'));
+    }
+  }
+
+  // kDestroy is called to actually free the QuicSocket resources and
+  // cause the error and close events to be emitted.
+  [kDestroy](error) {
+    // The QuicSocket will be destroyed once all QuicEndpoints
+    // are destroyed. See [kEndpointClose].
+    for (const endpoint of this.#endpoints)
+      endpoint.destroy(error);
+  }
+
+  // kMaybeDestroy is called one or more times after the close() method
+  // is called. The QuicSocket will be destroyed if there are no remaining
+  // open sessions.
+  [kMaybeDestroy]() {
+    if (this.closing && this.#sessions.size === 0) {
+      this.destroy();
+      return true;
+    }
+    return false;
+  }
+
+  // Called by the C++ internals to notify when server busy status is toggled.
+  [kServerBusy](on) {
+    this.#serverBusy = on;
+    process.nextTick(emit.bind(this, 'busy', on));
+  }
+
+  addEndpoint(options = {}) {
+    if (this.#state === kSocketDestroyed)
+      throw new ERR_QUICSOCKET_DESTROYED('listen');
+
+    // TODO(@jasnell): Also forbid adding an endpoint if
+    // the QuicSocket is closing.
+
+    const endpoint = new QuicEndpoint(this, options);
+    this.#endpoints.add(endpoint);
+
+    // If the QuicSocket is already bound at this point,
+    // also bind the newly created QuicEndpoint.
+    if (this.#state !== kSocketUnbound)
+      endpoint[kMaybeBind]();
+
+    return endpoint;
+  }
+
+  // Used only from within the #continueListen function. When a preferred
+  // address has been provided, the hostname given must be resolved into an
+  // IP address, which must be passed on to #completeListen or the QuicSocket
+  // needs to be destroyed.
+  static #afterPreferredAddressLookup = function(
+    transportParams,
+    port,
+    type,
+    err,
+    address) {
+    if (err) {
+      this.destroy(err);
+      return;
+    }
+    this.#completeListen(transportParams, { address, port, type });
+  };
+
+  // The #completeListen function is called after all of the necessary
   // DNS lookups have been performed and we're ready to let the C++
   // internals begin listening for new QuicServerSession instances.
-  [kContinueListen](transportParams, preferredAddress) {
+  #completeListen = function(transportParams, preferredAddress) {
     const {
       address,
       port,
       type = AF_INET,
     } = { ...preferredAddress };
+
     const {
       rejectUnauthorized = !getAllowUnauthorized(),
       requestCert = false,
     } = transportParams;
 
     // Transport Parameters are passed to the C++ side using a shared array.
+    // These are the transport parameters that will be used when a new
+    // server QuicSession is established. They are transmitted to the client
+    // as part of the server's initial TLS handshake. Once they are set, they
+    // cannot be modified.
     setTransportParams(transportParams);
 
     const options =
@@ -1089,17 +1159,49 @@ class QuicSocket extends EventEmitter {
       this.#alpn,
       options);
     process.nextTick(emit.bind(this, 'listening'));
-  }
+  };
 
-  addEndpoint(options = {}) {
-    if (this.#state === kSocketDestroyed)
-      throw new ERR_QUICSOCKET_DESTROYED('listen');
-    const endpoint = new QuicEndpoint(this, options);
-    this.#endpoints.add(endpoint);
-    if (this.#state !== kSocketUnbound)
-      endpoint[kMaybeBind]();
-    return endpoint;
-  }
+  // When the QuicSocket listen() function is called, the first step is to bind
+  // the underlying QuicEndpoint's. Once at least one endpoint has been bound,
+  // the continueListen function is invoked to continue the process of starting
+  // to listen.
+  //
+  // The preferredAddress is a preferred network endpoint that the server wishes
+  // connecting clients to use. If specified, this will be communicate to the
+  // client as part of the tranport parameters exchanged during the TLS
+  // handshake.
+  #continueListen = function(transportParams, lookup) {
+    const { preferredAddress } = transportParams;
+
+    // TODO(@jasnell): Currently, we wait to start resolving the
+    // preferred address until after we know the QuicSocket is
+    // bound. That's not strictly necessary as we can resolve the
+    // preferred address in parallel, which out to be faster but
+    // is a slightly more complicated to coordinate. In the future,
+    // we should do those things in parallel.
+    if (preferredAddress && typeof preferredAddress === 'object') {
+      const {
+        address,
+        port,
+        type = 'udp4',
+      } = { ...preferredAddress };
+      const typeVal = getSocketType(type);
+      // If preferred address is set, we need to perform a lookup on it
+      // to get the IP address. Only after that lookup completes can we
+      // continue with the listen operation, passing in the resolved
+      // preferred address.
+      lookup(
+        address || (typeVal === AF_INET6 ? '::' : '0.0.0.0'),
+        QuicSocket.#afterPreferredAddressLookup.bind(
+          this,
+          transportParams,
+          port,
+          typeVal));
+      return;
+    }
+    // If preferred address is not set, we can skip directly to the listen
+    this.#completeListen(transportParams);
+  };
 
   // Begin listening for server connections. The callback that may be
   // passed to this function is registered as a handler for the
@@ -1131,9 +1233,9 @@ class QuicSocket extends EventEmitter {
     // The ALPN protocol identifier is strictly required.
     const {
       alpn,
-      transportParams,
-      highWaterMark,
       defaultEncoding,
+      highWaterMark,
+      transportParams,
     } = validateQuicSocketListenOptions(options);
 
     // Store the secure context so that it is not garbage collected
@@ -1159,24 +1261,38 @@ class QuicSocket extends EventEmitter {
       this.on('session', callback);
 
     // Bind the QuicSocket to the local port if it hasn't been bound already.
-    this[kMaybeBind]();
-
-    const doListen = continueListen.bind(this, transportParams, this.#lookup);
-
-    // If the QuicSocket is already bound, we'll begin listening
-    // immediately. If we're still pending, however, wait until
-    // the 'ready' event is emitted, then carry on.
-    // TODO(@jasnell): Move the on ready handling to the kReady function
-    // to avoid having to register the handler here.
-    if (this.#state === kSocketPending) {
-      this.once('ready', doListen);
-      return;
-    }
-    doListen();
+    this[kMaybeBind](this.#continueListen.bind(
+      this,
+      transportParams,
+      this.#lookup));
   }
+
+  // When the QuicSocket connect() function is called, the first step is to bind
+  // the underlying QuicEndpoint's. Once at least one endpoint has been bound,
+  // the connectAfterBind function is invoked to continue the connection
+  // process.
+  //
+  // The immediate next step is to resolve the address into an ip address.
+  #continueConnect = function(session, lookup, address, type) {
+    // TODO(@jasnell): Currently, we perform the DNS resolution after
+    // the QuicSocket has been bound. We don't have to. We could do
+    // it in parallel while we're waitint to be bound but doing so
+    // is slightly more complicated.
+
+    // Notice here that connectAfterLookup is bound to the QuicSession
+    // that was created...
+    lookup(
+      address || (type === AF_INET6 ? '::' : '0.0.0.0'),
+      connectAfterLookup.bind(session, type));
+  };
 
   // Creates and returns a new QuicClientSession.
   connect(options, callback) {
+    if (this.#state === kSocketDestroyed ||
+      this.#state === kSocketClosing) {
+      throw new ERR_QUICSOCKET_DESTROYED('connect');
+    }
+
     if (typeof options === 'function') {
       callback = options;
       options = undefined;
@@ -1192,11 +1308,6 @@ class QuicSocket extends EventEmitter {
       address,
     } = validateQuicSocketConnectOptions(options);
 
-    if (this.#state === kSocketDestroyed ||
-        this.#state === kSocketClosing) {
-      throw new ERR_QUICSOCKET_DESTROYED('connect');
-    }
-
     const session = new QuicClientSession(this, options);
 
     // TODO(@jasnell): This likely should listen for the secure event
@@ -1204,7 +1315,7 @@ class QuicSocket extends EventEmitter {
     if (typeof callback === 'function')
       session.once('ready', callback);
 
-    this[kMaybeBind](connectAfterBind.bind(
+    this[kMaybeBind](this.#continueConnect.bind(
       this,
       session,
       this.#lookup,
@@ -1212,52 +1323,6 @@ class QuicSocket extends EventEmitter {
       type));
 
     return session;
-  }
-
-  [kEndpointBound](endpoint) {
-    if (this.#state === kSocketBound)
-      return;
-    this.#state = kSocketBound;
-    for (const session of this.#sessions)
-      session[kReady]();
-    process.nextTick(emit.bind(this, 'ready'));
-  }
-
-  // Called when a QuicEndpoint closes
-  [kEndpointClose](endpoint, error) {
-    this.#endpoints.delete(endpoint);
-    process.nextTick(emit.bind(this, 'endpointClose', endpoint, error));
-    if (this.#endpoints.size === 0) {
-      // Ensure that there are absolutely no additional sessions
-      for (const session of this.#sessions)
-        session.destroy(error);
-
-      if (error) process.nextTick(emit.bind(this, 'error', error));
-      process.nextTick(emit.bind(this, 'close'));
-    }
-  }
-
-  // kDestroy is called to actually free the QuicSocket resources and
-  // cause the error and close events to be emitted.
-  [kDestroy](error) {
-    for (const endpoint of this.#endpoints)
-      endpoint.destroy(error);
-  }
-
-  // kMaybeDestroy is called one or more times after the close() method
-  // is called. The QuicSocket will be destroyed if there are no remaining
-  // open sessions.
-  [kMaybeDestroy]() {
-    if (this.#state !== kSocketDestroyed && this.#sessions.size === 0) {
-      this.destroy();
-      return true;
-    }
-    return false;
-  }
-
-  [kServerBusy](on) {
-    this.#serverBusy = on;
-    process.nextTick(emit.bind(this, 'busy', on));
   }
 
   // Initiate a Graceful Close of the QuicSocket.
@@ -1395,22 +1460,36 @@ class QuicSocket extends EventEmitter {
     return Array.from(this.#endpoints);
   }
 
+  // The sever secure context is the SecureContext specified when calling
+  // listen. It is the context that will be used with all new server
+  // QuicSession instances.
   get serverSecureContext() {
     return this.#serverSecureContext;
   }
 
+  // True if at least one associated QuicEndpoint has been successfully
+  // bound to a local UDP port.
+  get bound() {
+    return this.#state === kSocketBound;
+  }
+
+  // True if graceful close has been initiated by calling close()
   get closing() {
     return this.#state === kSocketClosing;
   }
 
+  // True if the QuicSocket has been destroyed and is no longer usable
   get destroyed() {
     return this.#state === kSocketDestroyed;
   }
 
+  // True if listen() has been called successfully
   get listening() {
     return this.#serverListening;
   }
 
+  // True if the QuicSocket is currently waiting on at least one
+  // QuicEndpoint to succesfully bind.g
   get pending() {
     return this.#state === kSocketPending;
   }
@@ -1421,22 +1500,29 @@ class QuicSocket extends EventEmitter {
     if (this.#state === kSocketDestroyed)
       throw new ERR_QUICSOCKET_DESTROYED('setServerBusy');
     validateBoolean(on, 'on');
-    this[kHandle].setServerBusy(on);
+    if (this.#serverBusy !== on)
+      this[kHandle].setServerBusy(on);
   }
 
   get duration() {
+    // TODO(@jasnell): If the object is destroyed, it should
+    // use a fixed duration rather than calculating from now
     const now = process.hrtime.bigint();
     const stats = this.#stats || this[kHandle].stats;
     return now - stats[IDX_QUIC_SOCKET_STATS_CREATED_AT];
   }
 
   get boundDuration() {
+    // TODO(@jasnell): If the object is destroyed, it should
+    // use a fixed duration rather than calculating from now
     const now = process.hrtime.bigint();
     const stats = this.#stats || this[kHandle].stats;
     return now - stats[IDX_QUIC_SOCKET_STATS_BOUND_AT];
   }
 
   get listenDuration() {
+    // TODO(@jasnell): If the object is destroyed, it should
+    // use a fixed duration rather than calculating from now
     const now = process.hrtime.bigint();
     const stats = this.#stats || this[kHandle].stats;
     return now - stats[IDX_QUIC_SOCKET_STATS_LISTEN_AT];
@@ -1535,6 +1621,7 @@ class QuicSession extends EventEmitter {
   #closeFamily = QUIC_ERROR_APPLICATION;
   #closing = false;
   #destroyed = false;
+  #earlyData = false;
   #handshakeComplete = false;
   #idleTimeout = false;
   #maxPacketLength = IDX_QUIC_SESSION_MAX_PACKET_SIZE_DEFAULT;
@@ -1542,6 +1629,7 @@ class QuicSession extends EventEmitter {
   #socket = undefined;
   #statelessReset = false;
   #stats = undefined;
+  #pendingStreams = new Set();
   #streams = new Map();
   #verifyErrorReason = undefined;
   #verifyErrorCode = undefined;
@@ -1561,13 +1649,15 @@ class QuicSession extends EventEmitter {
     this.on('newListener', onNewListener);
     this.on('removeListener', onRemoveListener);
     this.#socket = socket;
-    socket[kAddSession](this);
     this.#servername = servername;
     this.#alpn = alpn;
     this.#highWaterMark = highWaterMark;
     this.#defaultEncoding = defaultEncoding;
+    socket[kAddSession](this);
   }
 
+  // kGetStreamOptions is called to get the configured options
+  // for peer initiated QuicStream instances.
   [kGetStreamOptions]() {
     return {
       highWaterMark: this.#highWaterMark,
@@ -1575,6 +1665,12 @@ class QuicSession extends EventEmitter {
     };
   }
 
+  // Sets the internal handle for the QuicSession instance. For
+  // server QuicSessions, this is called immediately as the
+  // handle is created before the QuicServerSession JS object.
+  // For client QuicSession instances, the connect() method
+  // must first perform DNS resolution on the provided address
+  // before the underlying QuicSession handle can be created.
   [kSetHandle](handle) {
     this[kHandle] = handle;
     if (handle !== undefined) {
@@ -1589,6 +1685,10 @@ class QuicSession extends EventEmitter {
     }
   }
 
+  // Called when a client QuicSession instance receives a version
+  // negotiation packet from the server peer. The client QuicSession
+  // is destroyed immediately. This is not called at all for server
+  // QuicSessions.
   [kVersionNegotiation](version, requestedVersions, supportedVersions) {
     const err =
       new ERR_QUICSESSION_VERSION_NEGOTIATION(
@@ -1603,6 +1703,8 @@ class QuicSession extends EventEmitter {
     this.destroy(err);
   }
 
+  // Causes the QuicSession to be immediately destroyed, but with
+  // additional metadata set.
   [kDestroy](statelessReset, family, code) {
     this.#statelessReset = !!statelessReset;
     this.#closeCode = code;
@@ -1610,14 +1712,13 @@ class QuicSession extends EventEmitter {
     this.destroy();
   }
 
+  // Immediate close has been initiated for the session. Any
+  // still open QuicStreams must be abandoned and shutdown
+  // with RESET_STREAM and STOP_SENDING frames transmitted
+  // as appropriate. Once the streams have been shutdown, a
+  // CONNECTION_CLOSE will be generated and sent, switching
+  // the session into the closing period.
   [kClose](family, code) {
-    // Immediate close has been initiated for the session. Any
-    // still open QuicStreams must be abandoned and shutdown
-    // with RESET_STREAM and STOP_SENDING frames transmitted
-    // as appropriate. Once the streams have been shutdown, a
-    // CONNECTION_CLOSE will be generated and sent, switching
-    // the session into the closing period.
-
     // Do nothing if the QuicSession has already been destroyed.
     if (this.#destroyed)
       return;
@@ -1625,6 +1726,11 @@ class QuicSession extends EventEmitter {
     // Set the close code and family so we can keep track.
     this.#closeCode = code;
     this.#closeFamily = family;
+
+    // Shutdown all pending streams. These are Streams that
+    // have been created but do not yet have a handle assigned.
+    for (const stream of this.#pendingStreams)
+      stream[kClose](family, code);
 
     // Shutdown all of the remaining streams
     for (const stream of this.#streams.values())
@@ -1637,6 +1743,8 @@ class QuicSession extends EventEmitter {
     this[kHandle].close(family, code);
   }
 
+  // Closes the specified stream with the given code. The
+  // QuicStream object will be destroyed.
   [kStreamClose](id, code) {
     const stream = this.#streams.get(id);
     if (stream === undefined)
@@ -1645,6 +1753,9 @@ class QuicSession extends EventEmitter {
     stream.destroy();
   }
 
+  // Delivers a block of headers to the appropriate QuicStream
+  // instance. This will only be called if the ALPN selected
+  // is known to support headers.
   [kHeaders](id, headers, kind, push_id) {
     const stream = this.#streams.get(id);
     if (stream === undefined)
@@ -1668,6 +1779,7 @@ class QuicSession extends EventEmitter {
       closing: this.closing,
       closeCode: this.closeCode,
       destroyed: this.destroyed,
+      earlyData: this.#earlyData,
       maxStreams: this.maxStreams,
       servername: this.servername,
       streams: this.#streams.size,
@@ -1683,6 +1795,7 @@ class QuicSession extends EventEmitter {
     this.#socket = socket;
   }
 
+  // Called at the completion of the TLS handshake for the local peer
   [kHandshake](
     servername,
     alpn,
@@ -1690,7 +1803,8 @@ class QuicSession extends EventEmitter {
     cipherVersion,
     maxPacketLength,
     verifyErrorReason,
-    verifyErrorCode) {
+    verifyErrorCode,
+    earlyData) {
     this.#handshakeComplete = true;
     this.#servername = servername;
     this.#alpn = alpn;
@@ -1699,7 +1813,7 @@ class QuicSession extends EventEmitter {
     this.#maxPacketLength = maxPacketLength;
     this.#verifyErrorReason = verifyErrorReason;
     this.#verifyErrorCode = verifyErrorCode;
-
+    this.#earlyData = earlyData;
     if (!this[kHandshakePost]())
       return;
 
@@ -1707,10 +1821,10 @@ class QuicSession extends EventEmitter {
       emit.bind(this, 'secure', servername, alpn, this.cipher));
   }
 
+  // Non-op for the default case. QuicClientSession
+  // overrides this with some client-side specific
+  // checks
   [kHandshakePost]() {
-    // Non-op for the default case. QuicClientSession
-    // overrides this with some client-side specific
-    // checks
     return true;
   }
 
@@ -1730,6 +1844,10 @@ class QuicSession extends EventEmitter {
       this.destroy();
   }
 
+  // Called when a client QuicSession has opted to use the
+  // server provided preferred address. This is a purely
+  // informationational notification. It is not called on
+  // server QuicSession instances.
   [kUsePreferredAddress](address) {
     process.nextTick(
       emit.bind(this, 'usePreferredAddress', address));
@@ -1795,6 +1913,12 @@ class QuicSession extends EventEmitter {
       error = new ERR_QUIC_ERROR(closeCode, closeFamily);
     }
 
+    // Destroy any pending streams immediately. These
+    // are streams that have been created but have not
+    // yet been assigned an internal handle.
+    for (const stream of this.#pendingStreams)
+      stream.destroy(error);
+
     // Destroy any remaining streams immediately.
     for (const stream of this.#streams.values())
       stream.destroy(error);
@@ -1821,6 +1945,16 @@ class QuicSession extends EventEmitter {
     // associated QuicSocket.
     this.#socket[kRemoveSession](this);
     this.#socket = undefined;
+  }
+
+  // For server QuicSession instances, true if earlyData is
+  // enabled. For client QuicSessions, true only if session
+  // resumption is used and early data was accepted during
+  // the TLS handshake. The value is set only after the
+  // TLS handshake is completed (immeditely before the
+  // secure event is emitted)
+  get earlyData() {
+    return this.#earlyData;
   }
 
   get maxStreams() {
@@ -1965,21 +2099,35 @@ class QuicSession extends EventEmitter {
       stream.read();
     }
 
-    // TODO(@jasnell): Once we've verified that 0RTT is working, then it should
-    // be possible to create the underlying stream before handshake completes.
-    if (!this.#handshakeComplete)
-      this.once('secure', QuicSession.#makeStream.bind(this, stream, halfOpen));
-    else
-      QuicSession.#makeStream.call(this, stream, halfOpen);
+    this.#pendingStreams.add(stream);
+
+    // If early data is being used, we can create the internal QuicStream on the
+    // ready event, that is immediately after the internal QuicSession handle
+    // has been created. Otherwise, we have to wait until the secure event
+    // signaling the completion of the TLS handshake.
+    const makeStream = QuicSession.#makeStream.bind(this, stream, halfOpen);
+    let deferred = false;
+    if (this.allowEarlyData && !this.ready) {
+      deferred = true;
+      this.once('ready', makeStream);
+    } else if (!this.handshakeComplete) {
+      deferred = true;
+      this.once('secure', makeStream);
+    }
+
+    if (!deferred)
+      makeStream(stream, halfOpen);
 
     return stream;
   }
 
   static #makeStream = function(stream, halfOpen) {
+    this.#pendingStreams.delete(stream);
     const handle =
       halfOpen ?
         _openUnidirectionalStream(this[kHandle]) :
         _openBidirectionalStream(this[kHandle]);
+
     if (handle === undefined) {
       stream.destroy(new ERR_QUICSTREAM_OPEN_FAILED());
       return;
@@ -1987,7 +2135,7 @@ class QuicSession extends EventEmitter {
 
     stream[kSetHandle](handle);
     this[kAddStream](stream.id, stream);
-  }
+  };
 
   get duration() {
     const now = process.hrtime.bigint();
@@ -2102,8 +2250,15 @@ class QuicServerSession extends QuicSession {
     } = options;
     super(socket, { highWaterMark, defaultEncoding });
     this[kSetHandle](handle);
+
+    // Both the handle and socket are immediately usable
+    // at this point so trigger the ready event.
+    this[kSocketReady]();
   }
 
+  // Called only when a clientHello event handler is registered.
+  // Allows user code an opportunity to interject into the start
+  // of the TLS handshake.
   [kClientHello](alpn, servername, ciphers, callback) {
     this.emit(
       'clientHello',
@@ -2113,10 +2268,8 @@ class QuicServerSession extends QuicSession {
       callback.bind(this[kHandle]));
   }
 
-  [kReady]() {
-    process.nextTick(emit.bind(this, 'ready'));
-  }
-
+  // Called only when an OCSPRequest event handler is registered.
+  // Allows user code the ability to answer the OCSP query.
   [kCert](servername, callback) {
     const { serverSecureContext } = this.socket;
     let { context } = serverSecureContext;
@@ -2136,6 +2289,14 @@ class QuicServerSession extends QuicSession {
       callback.bind(this[kHandle]));
   }
 
+  [kSocketReady]() {
+    process.nextTick(emit.bind(this, 'ready'));
+  }
+
+  get ready() { return true; }
+
+  get allowEarlyData() { return false; }
+
   addContext(servername, context = {}) {
     validateString(servername, 'servername');
     validateObject(context, 'context');
@@ -2149,40 +2310,19 @@ class QuicServerSession extends QuicSession {
   }
 }
 
-function setSocketAfterBind(socket, callback) {
-  if (socket.destroyed) {
-    callback(new ERR_QUICSOCKET_DESTROYED('setSocket'));
-    return;
-  }
-
-  if (!this[kHandle].setSocket(socket[kHandle])) {
-    callback(new ERR_QUICCLIENTSESSION_FAILED_SETSOCKET());
-    return;
-  }
-
-  if (this.socket) {
-    this.socket[kRemoveSession](this);
-    this[kSetSocket](undefined);
-  }
-  socket[kAddSession](this);
-  this[kSetSocket](socket);
-
-  callback();
-}
-
-let warnedVerifyHostnameIdentity;
-
 class QuicClientSession extends QuicSession {
+  #allowEarlyData = false;
+  #autoStart = true;
   #dcid = undefined;
-  #handleReady = false;
+  #handshakeStarted = false;
   #ipv6Only = undefined;
   #minDHSize = undefined;
   #port = undefined;
+  #ready = 0;
   #remoteTransportParams = undefined;
   #requestOCSP = undefined;
   #secureContext = undefined;
   #sessionTicket = undefined;
-  #socketReady = false;
   #transportParams = undefined;
   #preferredAddressPolicy;
   #verifyHostnameIdentity = true;
@@ -2194,6 +2334,7 @@ class QuicClientSession extends QuicSession {
       ...options
     };
     const {
+      autoStart,
       alpn,
       dcid,
       ipv6Only,
@@ -2220,21 +2361,32 @@ class QuicClientSession extends QuicSession {
     }
 
     super(socket, { servername, alpn, highWaterMark, defaultEncoding });
+    this.#autoStart = autoStart;
+    this.#handshakeStarted = autoStart;
     this.#dcid = dcid;
     this.#ipv6Only = ipv6Only;
     this.#minDHSize = minDHSize;
     this.#port = port || 0;
     this.#preferredAddressPolicy = preferredAddressPolicy;
-    this.#remoteTransportParams = remoteTransportParams;
     this.#requestOCSP = requestOCSP;
     this.#secureContext =
       createSecureContext(
         sc_options,
         initSecureContextClient);
-    this.#sessionTicket = sessionTicket;
     this.#transportParams = validateTransportParams(options);
     this.#verifyHostnameIdentity = verifyHostnameIdentity;
     this.#qlogEnabled = qlog;
+
+    // If provided, indicates that the client is attempting to
+    // resume a prior session. Early data would be enabled.
+    this.#remoteTransportParams = remoteTransportParams;
+    this.#sessionTicket = sessionTicket;
+    this.#allowEarlyData =
+      remoteTransportParams !== undefined &&
+      sessionTicket !== undefined;
+
+    if (socket.bound)
+      this[kSocketReady]();
   }
 
   [kHandshakePost]() {
@@ -2243,24 +2395,14 @@ class QuicClientSession extends QuicSession {
       this.destroy(new ERR_TLS_DH_PARAM_SIZE(size));
       return false;
     }
-
-    // TODO(@jasnell): QUIC *requires* that the client verify the
-    // identity of the server so we'll need to do that here.
-    // The current implementation of tls.checkServerIdentity is
-    // less than great and could be rewritten to speed it up
-    // significantly by running at the C++ layer. As it is
-    // currently, the method pulls the peer cert data, converts
-    // it to a javascript object, then processes the javascript
-    // object... which is more expensive than what is strictly
-    // necessary.
-    //
-    // See: _tls_wrap.js onConnectSecure function
-
     return true;
   }
 
+  [kCert](response) {
+    this.emit('OCSPResponse', response);
+  }
+
   [kContinueConnect](type, ip) {
-    const flags = this.#ipv6Only ? UV_UDP_IPV6ONLY : 0;
     setTransportParams(this.#transportParams);
 
     const options =
@@ -2275,7 +2417,6 @@ class QuicClientSession extends QuicSession {
         type,
         ip,
         this.#port,
-        flags,
         this.#secureContext.context,
         this.servername || ip,
         this.#remoteTransportParams,
@@ -2284,12 +2425,16 @@ class QuicClientSession extends QuicSession {
         this.#preferredAddressPolicy,
         this.alpnProtocol,
         options,
-        this.#qlogEnabled);
+        this.#qlogEnabled,
+        this.#autoStart);
+
     // We no longer need these, unset them so
     // memory can be garbage collected.
     this.#remoteTransportParams = undefined;
     this.#sessionTicket = undefined;
     this.#dcid = undefined;
+
+    // If handle is a number, creating the session failed.
     if (typeof handle === 'number') {
       let reason;
       switch (handle) {
@@ -2309,11 +2454,10 @@ class QuicClientSession extends QuicSession {
       return;
     }
 
-    this[kInit](handle);
-  }
-
-  [kInit](handle) {
     this[kSetHandle](handle);
+
+    // Listeners may have been added before the handle was created.
+    // Ensure that we toggle those listeners in the handle state.
 
     if (this.listenerCount('keylog') > 0)
       toggleListeners(handle, 'keylog', true);
@@ -2324,26 +2468,45 @@ class QuicClientSession extends QuicSession {
     if (this.listenerCount('usePreferredAddress') > 0)
       toggleListeners(handle, 'usePreferredAddress', true);
 
-    this.#handleReady = true;
-    this[kMaybeReady]();
+    this.#maybeReady(0x2);
   }
 
-  [kReady]() {
-    this.#socketReady = true;
-    this[kMaybeReady]();
+  [kSocketReady]() {
+    this.#maybeReady(0x1);
   }
 
-  [kCert](response) {
-    this.emit('OCSPResponse', response);
-  }
-
-  [kMaybeReady]() {
-    if (this.#socketReady && this.#handleReady)
+  // The QuicClientSession is ready for use only after
+  // (a) The QuicSocket has been bound and
+  // (b) The internal handle has been created
+  #maybeReady = function(flag) {
+    this.#ready |= flag;
+    if (this.ready)
       process.nextTick(emit.bind(this, 'ready'));
+  };
+
+  get allowEarlyData() {
+    return this.#allowEarlyData;
   }
 
   get ready() {
-    return this.#handleReady && this.#socketReady;
+    return this.#ready === 0x3;
+  }
+
+  get handshakeStarted() {
+    return this.#handshakeStarted;
+  }
+
+  startHandshake() {
+    if (this.destroyed)
+      throw new ERR_QUICSESSION_DESTROYED('startHandshake');
+    if (this.#handshakeStarted)
+      return;
+    this.#handshakeStarted = true;
+    if (!this.ready) {
+      this.once('ready', () => this.startHandshake());
+    } else {
+      this[kHandle].startHandshake();
+    }
   }
 
   get ephemeralKeyInfo() {
@@ -2352,6 +2515,27 @@ class QuicClientSession extends QuicSession {
       {};
   }
 
+  #setSocketAfterBind = function(socket, callback) {
+    if (socket.destroyed) {
+      callback(new ERR_QUICSOCKET_DESTROYED('setSocket'));
+      return;
+    }
+
+    if (!this[kHandle].setSocket(socket[kHandle])) {
+      callback(new ERR_QUICCLIENTSESSION_FAILED_SETSOCKET());
+      return;
+    }
+
+    if (this.socket) {
+      this.socket[kRemoveSession](this);
+      this[kSetSocket](undefined);
+    }
+    socket[kAddSession](this);
+    this[kSetSocket](socket);
+
+    callback();
+  };
+
   setSocket(socket, callback) {
     if (!(socket instanceof QuicSocket))
       throw new ERR_INVALID_ARG_TYPE('socket', 'QuicSocket', socket);
@@ -2359,12 +2543,8 @@ class QuicClientSession extends QuicSession {
     if (typeof callback !== 'function')
       throw new ERR_INVALID_CALLBACK();
 
-    socket[kMaybeBind](setSocketAfterBind.bind(this, socket, callback));
+    socket[kMaybeBind](() => this.#setSocketAfterBind(socket, callback));
   }
-}
-
-function afterShutdown() {
-  this.callback();
 }
 
 function streamOnResume() {
@@ -2404,6 +2584,7 @@ class QuicStream extends Duplex {
       decodeStrings: true,
       emitClose: true,
       autoDestroy: false,
+      captureRejections: true,
     });
     this.#highWaterMark = highWaterMark;
     this.#defaultEncoding = defaultEncoding;
@@ -2432,8 +2613,19 @@ class QuicStream extends Duplex {
         this.read();
       }
     }
+
+    // The QuicStream writes are corked until kSetHandle
+    // is set, ensuring that writes are buffered in JavaScript
+    // until we have somewhere to send them.
+    this.cork();
   }
 
+  // Set handle is called once the QuicSession has been able
+  // to complete creation of the internal QuicStream handle.
+  // This will happen only after the QuicSession's own
+  // internal handle has been created. The QuicStream object
+  // is still minimally usable before this but any data
+  // written will be buffered until kSetHandle is called.
   [kSetHandle](handle) {
     this[kHandle] = handle;
     if (handle !== undefined) {
@@ -2444,6 +2636,7 @@ class QuicStream extends Duplex {
       this.#dataRateHistogram = new Histogram(handle.rate);
       this.#dataSizeHistogram = new Histogram(handle.size);
       this.#dataAckHistogram = new Histogram(handle.ack);
+      this.uncork();
       this.emit('ready');
     } else {
       if (this.#dataRateHistogram)
@@ -2525,30 +2718,6 @@ class QuicStream extends Duplex {
       this.end();
   }
 
-  get pending() {
-    return this.#id === undefined;
-  }
-
-  get aborted() {
-    return this.#aborted;
-  }
-
-  get serverInitiated() {
-    return !!(this.#id & 0b01);
-  }
-
-  get clientInitiated() {
-    return !this.serverInitiated;
-  }
-
-  get unidirectional() {
-    return !!(this.#id & 0b10);
-  }
-
-  get bidirectional() {
-    return !this.unidirectional;
-  }
-
   [kAfterAsyncWrite]({ bytes }) {
     // TODO(@jasnell): Implement this
   }
@@ -2578,13 +2747,46 @@ class QuicStream extends Duplex {
     // this[kHandle].chunksSentSinceLastWrite = 0;
   }
 
-  [kWriteGeneric](writev, data, encoding, cb) {
+  [kUpdateTimer]() {
+    // TODO(@jasnell): Implement this later
+  }
+
+  get pending() {
+    // The id is set in the kSetHandle function
+    return this.#id === undefined;
+  }
+
+  get aborted() {
+    return this.#aborted;
+  }
+
+  get serverInitiated() {
+    return !!(this.#id & 0b01);
+  }
+
+  get clientInitiated() {
+    return !this.serverInitiated;
+  }
+
+  get unidirectional() {
+    return !!(this.#id & 0b10);
+  }
+
+  get bidirectional() {
+    return !this.unidirectional;
+  }
+
+  #writeGeneric = function(writev, data, encoding, cb) {
     if (this.destroyed)
       return;  // TODO(addaleax): Can this happen?
 
+    // The stream should be corked while still pending
+    // but just in case uncork
+    // was called early, defer the actual write until the
+    // ready event is emitted.
     if (this.pending) {
       return this.once('ready', () => {
-        this[kWriteGeneric](writev, data, encoding, cb);
+        this.#writeGeneric(writev, data, encoding, cb);
       });
     }
 
@@ -2594,14 +2796,14 @@ class QuicStream extends Duplex {
       writeGeneric(this, data, encoding, cb);
 
     this[kTrackWriteState](this, req.bytes);
-  }
+  };
 
   _write(data, encoding, cb) {
-    this[kWriteGeneric](false, data, encoding, cb);
+    this.#writeGeneric(false, data, encoding, cb);
   }
 
   _writev(data, cb) {
-    this[kWriteGeneric](true, data, '', cb);
+    this.#writeGeneric(true, data, '', cb);
   }
 
   // Called when the last chunk of data has been
@@ -2611,6 +2813,10 @@ class QuicStream extends Duplex {
   // coming so that a fin stream packet can be
   // sent.
   _final(cb) {
+    // The QuicStream should be corked while pending
+    // so this shouldn't be called, but just in case
+    // the stream was prematurely uncorked, defer the
+    // operation until the ready event is emitted.
     if (this.pending)
       return this.once('ready', () => this._final(cb));
 
@@ -2621,12 +2827,11 @@ class QuicStream extends Duplex {
     }
 
     const req = new ShutdownWrap();
-    req.oncomplete = afterShutdown;
-    req.callback = cb;
+    req.oncomplete = () => cb();
     req.handle = handle;
     const err = handle.shutdown(req);
     if (err === 1)
-      return afterShutdown.call(req, 0);
+      return cb();
   }
 
   _read(nread) {
@@ -2667,7 +2872,7 @@ class QuicStream extends Duplex {
     }
 
     this.sendFD(fd, options, true);
-  }
+  };
 
   sendFD(fd, { offset = -1, length = -1 } = {}, ownsFd = false) {
     if (this.destroyed || this.#closed)
@@ -2721,14 +2926,14 @@ class QuicStream extends Duplex {
       this.source.close().catch(stream.destroy.bind(stream));
     else
       this.source.releaseFD();
-  }
+  };
 
   static #onPipedFileHandleRead = function() {
     const err = streamBaseState[kReadBytesOrError];
     if (err < 0 && err !== UV_EOF) {
       this.stream.destroy(errnoException(err, 'sendFD'));
     }
-  }
+  };
 
   get resetReceived() {
     return (this.#resetCode !== undefined) ?
@@ -2773,10 +2978,6 @@ class QuicStream extends Duplex {
 
   _onTimeout() {
     // TODO(@jasnell): Implement this
-  }
-
-  [kUpdateTimer]() {
-    // TODO(@jasnell): Implement this later
   }
 
   get dataRateHistogram() {
@@ -3095,3 +3296,48 @@ module.exports = {
 //     * Destroy and free the QuicStream handle immediately
 //     * If Error, emit Error event
 //     * Emit Close event
+
+// QuicEndpoint States:
+//   Initial                 -- Created, Endpoint not yet bound to local UDP
+//                              port.
+//   Pending                 -- Binding to local UDP port has been initialized.
+//   Bound                   -- Binding to local UDP port has completed.
+//   Closed                  -- Endpoint has been unbound from the local UDP
+//                              port.
+//   Error                   -- An error has been encountered, endpoint has
+//                              been unbound and is no longer usable.
+//
+// QuicSocket States:
+//   Initial                 -- Created, QuicSocket has at least one
+//                              QuicEndpoint. All QuicEndpoints are in the
+//                              Initial state.
+//   Pending                 -- QuicSocket has at least one QuicEndpoint in the
+//                              Pending state.
+//   Bound                   -- QuicSocket has at least one QuicEndpoint in the
+//                              Bound state.
+//   Closed                  -- All QuicEndpoints are in the closed state.
+//   Destroyed               -- QuicSocket is no longer usable
+//   Destroyed-With-Error    -- An error has been encountered, socket is no
+//                              longer usable
+//
+// QuicSession States:
+//   Initial                 -- Created, QuicSocket state undetermined,
+//                              no internal QuicSession Handle assigned.
+//   Ready
+//     QuicSocket Ready        -- QuicSocket in Bound state.
+//     Handle Assigned         -- Internal QuicSession Handle assigned.
+//   TLS Handshake Started   --
+//   TLS Handshake Completed --
+//   TLS Handshake Confirmed --
+//   Closed                  -- Graceful Close Initiated
+//   Destroyed               -- QuicSession is no longer usable
+//   Destroyed-With-Error    -- An error has been encountered, session is no
+//                              longer usable
+//
+// QuicStream States:
+//   Initial Writable/Corked -- Created, QuicSession in Initial State
+//   Open Writable/Uncorked  -- QuicSession in Ready State
+//   Closed                  -- Graceful Close Initiated
+//   Destroyed               -- QuicStream is no longer usable
+//   Destroyed-With-Error    -- An error has been encountered, stream is no
+//                              longer usable

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -1953,7 +1953,7 @@ class QuicSession extends EventEmitter {
   // the TLS handshake. The value is set only after the
   // TLS handshake is completed (immeditely before the
   // secure event is emitted)
-  get earlyData() {
+  get usingEarlyData() {
     return this.#earlyData;
   }
 

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -2503,7 +2503,7 @@ class QuicClientSession extends QuicSession {
       return;
     this.#handshakeStarted = true;
     if (!this.ready) {
-      this.once('ready', () => this.startHandshake());
+      this.once('ready', () => this[kHandle].startHandshake());
     } else {
       this[kHandle].startHandshake();
     }

--- a/lib/internal/quic/util.js
+++ b/lib/internal/quic/util.js
@@ -267,6 +267,7 @@ function validateQuicClientSessionOptions(options = {}) {
   if (options !== null && typeof options !== 'object')
     throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
   const {
+    autoStart = true,
     address = 'localhost',
     alpn = '',
     dcid: dcid_value,
@@ -284,6 +285,7 @@ function validateQuicClientSessionOptions(options = {}) {
     defaultEncoding,
   } = options;
 
+  validateBoolean(autoStart, 'options.autoStart');
   validateNumber(minDHSize, 'options.minDHSize');
   validatePort(port, 'options.port');
   validateString(address, 'options.address');
@@ -340,6 +342,7 @@ function validateQuicClientSessionOptions(options = {}) {
   validateBoolean(qlog, 'options.qlog');
 
   return {
+    autoStart,
     address,
     alpn,
     dcid,
@@ -498,10 +501,10 @@ function validateQuicSocketListenOptions(options = {}) {
   validateObject(options);
   const {
     alpn = NGTCP2_ALPN_H3,
-    rejectUnauthorized,
-    requestCert,
-    highWaterMark,
     defaultEncoding,
+    highWaterMark,
+    requestCert,
+    rejectUnauthorized,
   } = options;
   validateString(alpn, 'options.alpn');
   validateBoolean(
@@ -554,6 +557,7 @@ function validateCreateSecureContextOptions(options = {}) {
     groups = kDefaultGroups,
     honorCipherOrder,
     key,
+    earlyData = true,  // Early data is enabled by default
     passphrase,
     pfx,
     sessionIdContext,
@@ -561,6 +565,8 @@ function validateCreateSecureContextOptions(options = {}) {
   } = options;
   validateString(ciphers, 'option.ciphers');
   validateString(groups, 'option.groups');
+  validateBoolean(earlyData, 'option.earlyData', { allowUndefined: true });
+
   // Additional validation occurs within the tls
   // createSecureContext function.
   return {
@@ -574,6 +580,7 @@ function validateCreateSecureContextOptions(options = {}) {
     groups,
     honorCipherOrder,
     key,
+    earlyData,
     passphrase,
     pfx,
     sessionIdContext,

--- a/src/node_crypto_common.cc
+++ b/src/node_crypto_common.cc
@@ -60,6 +60,14 @@ bool SetTLSSession(SSL* ssl, const unsigned char* buf, size_t length) {
   return s != nullptr && SSL_set_session(ssl, s.get()) == 1;
 }
 
+bool SetTLSSession(SSL* ssl, SSLSessionPointer session) {
+  return session != nullptr && SSL_set_session(ssl, session.get()) == 1;
+}
+
+SSLSessionPointer GetTLSSession(const unsigned char* buf, size_t length) {
+  return SSLSessionPointer(d2i_SSL_SESSION(nullptr, &buf, length));
+}
+
 std::unordered_multimap<std::string, std::string>
 GetCertificateAltNames(
     X509* cert) {

--- a/src/node_crypto_common.h
+++ b/src/node_crypto_common.h
@@ -26,6 +26,10 @@ std::string GetSSLOCSPResponse(SSL* ssl);
 
 bool SetTLSSession(SSL* ssl, const unsigned char* buf, size_t length);
 
+bool SetTLSSession(SSL* ssl, SSLSessionPointer session);
+
+SSLSessionPointer GetTLSSession(const unsigned char* buf, size_t length);
+
 std::unordered_multimap<std::string, std::string>
 GetCertificateAltNames(X509* cert);
 

--- a/src/quic/node_quic.cc
+++ b/src/quic/node_quic.cc
@@ -83,12 +83,16 @@ void QuicInitSecureContext(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   CHECK(args[0]->IsObject());  // Secure Context
   CHECK(args[1]->IsString());  // groups
+  CHECK(args[2]->IsBoolean()); // early data
+
   SecureContext* sc;
   ASSIGN_OR_RETURN_UNWRAP(&sc, args[0].As<Object>(),
                           args.GetReturnValue().Set(UV_EBADF));
   const node::Utf8Value groups(env->isolate(), args[1]);
 
-  InitializeSecureContext(sc, side);
+  bool early_data = args[2]->BooleanValue(env->isolate());
+
+  InitializeSecureContext(sc, early_data, side);
 
   if (!crypto::SetGroups(sc, *groups))
     THROW_ERR_QUIC_CANNOT_SET_GROUPS(env);

--- a/src/quic/node_quic_crypto.cc
+++ b/src/quic/node_quic_crypto.cc
@@ -35,6 +35,21 @@ using v8::Value;
 
 namespace quic {
 
+bool SessionTicketAppData::Set(const uint8_t* data, size_t len) const {
+  if (set_)
+    return false;
+  set_ = true;
+  SSL_SESSION_set1_ticket_appdata(session_, data, len);
+  return set_;
+}
+
+bool SessionTicketAppData::Get(uint8_t** data, size_t* len) const {
+  return SSL_SESSION_get0_ticket_appdata(
+      session_,
+      reinterpret_cast<void**>(data),
+      len) == 1;
+}
+
 namespace {
 constexpr int kCryptoTokenKeylen = 32;
 constexpr int kCryptoTokenIvlen = 32;
@@ -626,6 +641,49 @@ int New_Session_Callback(SSL* ssl, SSL_SESSION* session) {
   return s->set_session(session);
 }
 
+int GenerateSessionTicket(SSL* ssl, void* arg) {
+  QuicSession* s = static_cast<QuicSession*>(SSL_get_app_data(ssl));
+  SessionTicketAppData app_data(SSL_get_session(ssl));
+  s->SetSessionTicketAppData(app_data);
+  return 1;
+}
+
+SSL_TICKET_RETURN DecryptSessionTicket(
+    SSL* ssl,
+    SSL_SESSION* session,
+    const unsigned char* keyname,
+    size_t keyname_len,
+    SSL_TICKET_STATUS status,
+    void* arg) {
+  QuicSession* s = static_cast<QuicSession*>(SSL_get_app_data(ssl));
+  SessionTicketAppData::Flag flag = SessionTicketAppData::Flag::STATUS_NONE;
+  switch (status) {
+    default:
+      return SSL_TICKET_RETURN_IGNORE;
+    case SSL_TICKET_EMPTY:
+      // Fall through
+    case SSL_TICKET_NO_DECRYPT:
+      return SSL_TICKET_RETURN_IGNORE_RENEW;
+    case SSL_TICKET_SUCCESS_RENEW:
+      flag = SessionTicketAppData::Flag::STATUS_RENEW;
+      // Fall through
+    case SSL_TICKET_SUCCESS:
+      SessionTicketAppData app_data(session);
+      switch (s->GetSessionTicketAppData(app_data, flag)) {
+        default:
+          return SSL_TICKET_RETURN_IGNORE;
+        case SessionTicketAppData::Status::TICKET_IGNORE:
+          return SSL_TICKET_RETURN_IGNORE;
+        case SessionTicketAppData::Status::TICKET_IGNORE_RENEW:
+          return SSL_TICKET_RETURN_IGNORE_RENEW;
+        case SessionTicketAppData::Status::TICKET_USE:
+          return SSL_TICKET_RETURN_USE;
+        case SessionTicketAppData::Status::TICKET_USE_RENEW:
+          return SSL_TICKET_RETURN_USE_RENEW;
+      }
+  }
+}
+
 int SetEncryptionSecrets(
     SSL* ssl,
     OSSL_ENCRYPTION_LEVEL ossl_level,
@@ -746,23 +804,37 @@ void InitializeSecureContext(
     crypto::SecureContext* sc,
     bool early_data,
     ngtcp2_crypto_side side) {
-  constexpr auto ssl_server_opts =
-      (SSL_OP_ALL & ~SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS) |
-      SSL_OP_SINGLE_ECDH_USE |
-      SSL_OP_CIPHER_SERVER_PREFERENCE |
-      SSL_OP_NO_ANTI_REPLAY;
+  // TODO(@jasnell): Should this be a static value?
+  constexpr static unsigned char session_id_ctx[] = "node.js quic server";
   switch (side) {
     case NGTCP2_CRYPTO_SIDE_SERVER:
-      SSL_CTX_set_options(**sc, ssl_server_opts);
+      SSL_CTX_set_options(
+          **sc,
+          (SSL_OP_ALL & ~SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS) |
+          SSL_OP_SINGLE_ECDH_USE |
+          SSL_OP_CIPHER_SERVER_PREFERENCE |
+          SSL_OP_NO_ANTI_REPLAY);
+
       SSL_CTX_set_mode(**sc, SSL_MODE_RELEASE_BUFFERS);
 
       SSL_CTX_set_alpn_select_cb(**sc, AlpnSelection, nullptr);
       SSL_CTX_set_client_hello_cb(**sc, Client_Hello_CB, nullptr);
 
+      SSL_CTX_set_session_ticket_cb(
+          **sc,
+          GenerateSessionTicket,
+          DecryptSessionTicket,
+          nullptr);
+
       if (early_data) {
         SSL_CTX_set_max_early_data(**sc, 0xffffffff);
         SSL_CTX_set_allow_early_data_cb(**sc, AllowEarlyDataCB, nullptr);
       }
+
+      SSL_CTX_set_session_id_context(
+          **sc,
+          session_id_ctx,
+          sizeof(session_id_ctx) - 1);
       break;
     case NGTCP2_CRYPTO_SIDE_CLIENT:
       SSL_CTX_set_session_cache_mode(

--- a/src/quic/node_quic_crypto.cc
+++ b/src/quic/node_quic_crypto.cc
@@ -35,7 +35,7 @@ using v8::Value;
 
 namespace quic {
 
-bool SessionTicketAppData::Set(const uint8_t* data, size_t len) const {
+bool SessionTicketAppData::Set(const uint8_t* data, size_t len) {
   if (set_)
     return false;
   set_ = true;
@@ -804,7 +804,8 @@ void InitializeSecureContext(
     crypto::SecureContext* sc,
     bool early_data,
     ngtcp2_crypto_side side) {
-  // TODO(@jasnell): Should this be a static value?
+  // TODO(@jasnell): Using a static value for this at the moment but
+  // we need to determine if a non-static or per-session value is better.
   constexpr static unsigned char session_id_ctx[] = "node.js quic server";
   switch (side) {
     case NGTCP2_CRYPTO_SIDE_SERVER:

--- a/src/quic/node_quic_crypto.h
+++ b/src/quic/node_quic_crypto.h
@@ -47,6 +47,7 @@ bool SetCryptoSecrets(
 // QUIC side (client or server).
 void InitializeSecureContext(
     crypto::SecureContext* sc,
+    bool early_data,
     ngtcp2_crypto_side side);
 
 // Called in the QuicSession::InitServer and

--- a/src/quic/node_quic_crypto.h
+++ b/src/quic/node_quic_crypto.h
@@ -156,11 +156,11 @@ class SessionTicketAppData {
   };
 
   explicit SessionTicketAppData(SSL_SESSION* session) : session_(session) {}
-  bool Set(const uint8_t* data, size_t len) const;
+  bool Set(const uint8_t* data, size_t len);
   bool Get(uint8_t** data, size_t* len) const;
 
  private:
-  mutable bool set_ = false;
+  bool set_ = false;
   SSL_SESSION* session_;
 };
 

--- a/src/quic/node_quic_crypto.h
+++ b/src/quic/node_quic_crypto.h
@@ -11,6 +11,8 @@
 #include <ngtcp2/ngtcp2_crypto.h>
 #include <openssl/ssl.h>
 
+#include <vector>
+
 namespace node {
 
 namespace quic {
@@ -130,6 +132,29 @@ v8::Local<v8::Value> GetALPNProtocol(const QuicSession& session);
 
 ngtcp2_crypto_level from_ossl_level(OSSL_ENCRYPTION_LEVEL ossl_level);
 const char* crypto_level_name(ngtcp2_crypto_level level);
+
+class SessionTicketAppData {
+ public:
+  enum class Status {
+    TICKET_USE,
+    TICKET_USE_RENEW,
+    TICKET_IGNORE,
+    TICKET_IGNORE_RENEW
+  };
+
+  enum class Flag {
+    STATUS_NONE,
+    STATUS_RENEW
+  };
+
+  explicit SessionTicketAppData(SSL_SESSION* session) : session_(session) {}
+  bool Set(const uint8_t* data, size_t len) const;
+  bool Get(uint8_t** data, size_t* len) const;
+
+ private:
+  mutable bool set_ = false;
+  SSL_SESSION* session_;
+};
 
 }  // namespace quic
 }  // namespace node

--- a/src/quic/node_quic_crypto.h
+++ b/src/quic/node_quic_crypto.h
@@ -133,6 +133,14 @@ v8::Local<v8::Value> GetALPNProtocol(const QuicSession& session);
 ngtcp2_crypto_level from_ossl_level(OSSL_ENCRYPTION_LEVEL ossl_level);
 const char* crypto_level_name(ngtcp2_crypto_level level);
 
+// SessionTicketAppData is a utility class that is used only during
+// the generation or access of TLS stateless sesson tickets. It
+// exists solely to provide a easier way for QuicApplication instances
+// to set relevant metadata in the session ticket when it is created,
+// and the exract and subsequently verify that data when a ticket is
+// received and is being validated. The app data is completely opaque
+// to anything other than the server-side of the QuicApplication that
+// sets it.
 class SessionTicketAppData {
  public:
   enum class Status {

--- a/src/quic/node_quic_session-inl.h
+++ b/src/quic/node_quic_session-inl.h
@@ -116,8 +116,19 @@ void QuicCryptoContext::ResumeHandshake() {
 }
 
 // For 0RTT, this sets the TLS session data from the given buffer.
-bool QuicCryptoContext::set_session(const unsigned char* data, size_t length) {
-  return crypto::SetTLSSession(ssl(), data, length);
+bool QuicCryptoContext::set_session(crypto::SSLSessionPointer session) {
+  if (side_ == NGTCP2_CRYPTO_SIDE_CLIENT && session != nullptr) {
+    early_data_ =
+        SSL_SESSION_get_max_early_data(session.get()) == 0xffffffffUL;
+  }
+  return crypto::SetTLSSession(ssl(), std::move(session));
+}
+
+bool QuicCryptoContext::early_data() const {
+  return
+      (early_data_ &&
+       SSL_get_early_data_status(ssl()) == SSL_EARLY_DATA_ACCEPTED) ||
+      SSL_get_max_early_data(ssl()) == 0xffffffffUL;
 }
 
 void QuicCryptoContext::set_tls_alert(int err) {
@@ -180,6 +191,13 @@ void QuicSession::AssociateCID(const QuicCID& cid) {
 void QuicSession::DisassociateCID(const QuicCID& cid) {
   if (is_server())
     socket()->DisassociateCID(cid);
+}
+
+void QuicSession::StartHandshake() {
+  if (crypto_context_->is_handshake_started() || is_server())
+    return;
+  crypto_context_->handshake_started();
+  SendPendingData();
 }
 
 void QuicSession::ExtendMaxStreamData(int64_t stream_id, uint64_t max_data) {
@@ -352,6 +370,13 @@ bool QuicSession::is_in_draining_period() const {
 
 bool QuicSession::HasStream(int64_t id) const {
   return streams_.find(id) != std::end(streams_);
+}
+
+bool QuicSession::allow_early_data() const {
+  // TODO(@jasnell): For now, we always allow early data.
+  // Later there will be reasons we do not want to allow
+  // it, such as lack of available system resources.
+  return true;
 }
 
 bool QuicSession::is_gracefully_closing() const {

--- a/src/quic/node_quic_session-inl.h
+++ b/src/quic/node_quic_session-inl.h
@@ -379,6 +379,17 @@ bool QuicSession::allow_early_data() const {
   return true;
 }
 
+void QuicSession::SetSessionTicketAppData(
+    const SessionTicketAppData& app_data) {
+  application_->SetSessionTicketAppData(app_data);
+}
+
+SessionTicketAppData::Status QuicSession::GetSessionTicketAppData(
+    const SessionTicketAppData& app_data,
+    SessionTicketAppData::Flag flag) {
+  return application_->GetSessionTicketAppData(app_data, flag);
+}
+
 bool QuicSession::is_gracefully_closing() const {
   return is_flag_set(QUICSESSION_FLAG_GRACEFUL_CLOSING);
 }

--- a/src/quic/node_quic_session.cc
+++ b/src/quic/node_quic_session.cc
@@ -2205,7 +2205,6 @@ void QuicSession::SendPendingData() {
 int QuicSession::set_session(SSL_SESSION* session) {
   CHECK(!is_server());
   CHECK(!is_flag_set(QUICSESSION_FLAG_DESTROYED));
-
   int size = i2d_SSL_SESSION(session, nullptr);
   if (size > SecureContext::kMaxSessionSize)
     return 0;

--- a/src/quic/node_quic_session.cc
+++ b/src/quic/node_quic_session.cc
@@ -66,13 +66,13 @@ void SetConfig(Environment* env, int idx, uint64_t* val) {
 // the NODE_DEBUG_NATIVE=NGTCP2_DEBUG category.
 void Ngtcp2DebugLog(void* user_data, const char* fmt, ...) {
   QuicSession* session = static_cast<QuicSession*>(user_data);
-  if (!UNLIKELY(session->env()->debug_enabled(DebugCategory::NGTCP2_DEBUG)))
-    return;
   va_list ap;
   va_start(ap, fmt);
   std::string format(fmt, strlen(fmt) + 1);
   format[strlen(fmt)] = '\n';
-  // TODO(@jasnell): Debug() currently is not working with va_list here.
+  // Debug() does not work with the va_list here. So we use vfprintf
+  // directly instead. Ngtcp2DebugLog is only enabled when the debug
+  // category is enabled.
   vfprintf(stderr, format.c_str(), ap);
   va_end(ap);
 }

--- a/src/quic/node_quic_session.cc
+++ b/src/quic/node_quic_session.cc
@@ -66,11 +66,14 @@ void SetConfig(Environment* env, int idx, uint64_t* val) {
 // the NODE_DEBUG_NATIVE=NGTCP2_DEBUG category.
 void Ngtcp2DebugLog(void* user_data, const char* fmt, ...) {
   QuicSession* session = static_cast<QuicSession*>(user_data);
+  if (!UNLIKELY(session->env()->debug_enabled(DebugCategory::NGTCP2_DEBUG)))
+    return;
   va_list ap;
   va_start(ap, fmt);
   std::string format(fmt, strlen(fmt) + 1);
   format[strlen(fmt)] = '\n';
-  Debug(session->env(), DebugCategory::NGTCP2_DEBUG, format, ap);
+  // TODO(@jasnell): Debug() currently is not working with va_list here.
+  vfprintf(stderr, format.c_str(), ap);
   va_end(ap);
 }
 

--- a/src/quic/node_quic_session.cc
+++ b/src/quic/node_quic_session.cc
@@ -587,7 +587,10 @@ void JSQuicSessionListener::OnHandshakeCompleted() {
         v8::Undefined(env->isolate()).As<Value>(),
     err != 0 ?
         crypto::GetValidationErrorCode(env, err) :
-        v8::Undefined(env->isolate()).As<Value>()
+        v8::Undefined(env->isolate()).As<Value>(),
+    session()->crypto_context()->early_data() ?
+        v8::True(env->isolate()) :
+        v8::False(env->isolate())
   };
 
   // Grab a shared pointer to this to prevent the QuicSession
@@ -629,15 +632,7 @@ void JSQuicSessionListener::OnSessionTicket(int size, SSL_SESSION* sess) {
   HandleScope scope(env->isolate());
   Context::Scope context_scope(env->context());
 
-  unsigned int session_id_length;
-  const unsigned char* session_id_data =
-      SSL_SESSION_get_id(sess, &session_id_length);
-
   Local<Value> argv[] = {
-    Buffer::Copy(
-        env,
-        reinterpret_cast<const char*>(session_id_data),
-        session_id_length).ToLocalChecked(),
     v8::Undefined(env->isolate()),
     v8::Undefined(env->isolate())
   };
@@ -648,11 +643,11 @@ void JSQuicSessionListener::OnSessionTicket(int size, SSL_SESSION* sess) {
   memset(session_data, 0, size);
   i2d_SSL_SESSION(sess, &session_data);
   if (!session_ticket.empty())
-    argv[1] = session_ticket.ToBuffer().ToLocalChecked();
+    argv[0] = session_ticket.ToBuffer().ToLocalChecked();
 
   if (session()->is_flag_set(
           QuicSession::QUICSESSION_FLAG_HAS_TRANSPORT_PARAMS)) {
-    argv[2] = Buffer::Copy(
+    argv[1] = Buffer::Copy(
         env,
         reinterpret_cast<const char*>(&session()->transport_params_),
         sizeof(session()->transport_params_)).ToLocalChecked();
@@ -1341,8 +1336,8 @@ QuicSession::QuicSession(
     const SocketAddress& local_addr,
     const SocketAddress& remote_addr,
     SecureContext* context,
-    Local<Value> early_transport_params,
-    Local<Value> session_ticket,
+    ngtcp2_transport_params* early_transport_params,
+    crypto::SSLSessionPointer early_session_ticket,
     Local<Value> dcid,
     PreferredAddressStrategy preferred_address_strategy,
     const std::string& alpn,
@@ -1360,13 +1355,13 @@ QuicSession::QuicSession(
         QuicCID(),
         options,
         preferred_address_strategy) {
-  CHECK(InitClient(
+  InitClient(
       local_addr,
       remote_addr,
       early_transport_params,
-      session_ticket,
+      std::move(early_session_ticket),
       dcid,
-      qlog));
+      qlog);
 }
 
 // QuicSession is an abstract base class that defines the code used by both
@@ -1892,6 +1887,7 @@ bool QuicSession::ReceiveClientInitial(const QuicCID& dcid) {
   if (UNLIKELY(is_flag_set(QUICSESSION_FLAG_DESTROYED)))
     return false;
   Debug(this, "Receiving client initial parameters");
+  crypto_context_->handshake_started();
   return DeriveAndInstallInitialKey(*this, dcid);
 }
 
@@ -2202,20 +2198,6 @@ void QuicSession::SendPendingData() {
   }
 }
 
-// When resuming a client session, the serialized transport parameters from
-// the prior session must be provided. This is set during construction
-// of the client QuicSession object.
-bool QuicSession::set_early_transport_params(Local<Value> buffer) {
-  CHECK(!is_server());
-  ArrayBufferViewContents<uint8_t> sbuf(buffer.As<ArrayBufferView>());
-  ngtcp2_transport_params params;
-  if (sbuf.length() != sizeof(ngtcp2_transport_params))
-    return false;
-  memcpy(&params, sbuf.data(), sizeof(ngtcp2_transport_params));
-  ngtcp2_conn_set_early_remote_transport_params(connection(), &params);
-  return true;
-}
-
 // When completing the TLS handshake, the TLS session information
 // is provided to the QuicSession so that the session ticket and
 // the remote transport parameters can be captured to support 0RTT
@@ -2229,15 +2211,6 @@ int QuicSession::set_session(SSL_SESSION* session) {
     return 0;
   listener_->OnSessionTicket(size, session);
   return 1;
-}
-
-// When resuming a client session, the serialized session ticket from
-// the prior session must be provided. This is set during construction
-// of the client QuicSession object.
-bool QuicSession::set_session(Local<Value> buffer) {
-  CHECK(!is_server());
-  ArrayBufferViewContents<unsigned char> sbuf(buffer.As<ArrayBufferView>());
-  return crypto_context_->set_session(sbuf.data(), sbuf.length());
 }
 
 // A client QuicSession can be migrated to a different QuicSocket instance.
@@ -2712,8 +2685,8 @@ BaseObjectPtr<QuicSession> QuicSession::CreateClient(
     const SocketAddress& local_addr,
     const SocketAddress& remote_addr,
     SecureContext* context,
-    Local<Value> early_transport_params,
-    Local<Value> session_ticket,
+    ngtcp2_transport_params* early_transport_params,
+    crypto::SSLSessionPointer early_session_ticket,
     Local<Value> dcid,
     PreferredAddressStrategy preferred_address_strategy,
     const std::string& alpn,
@@ -2735,7 +2708,7 @@ BaseObjectPtr<QuicSession> QuicSession::CreateClient(
           remote_addr,
           context,
           early_transport_params,
-          session_ticket,
+          std::move(early_session_ticket),
           dcid,
           preferred_address_strategy,
           alpn,
@@ -2753,11 +2726,11 @@ BaseObjectPtr<QuicSession> QuicSession::CreateClient(
 // perform a 0RTT resumption of a prior session.
 // The dcid_value parameter is optional to allow user code the
 // ability to provide an explicit dcid (this should be rare)
-bool QuicSession::InitClient(
+void QuicSession::InitClient(
     const SocketAddress& local_addr,
     const SocketAddress& remote_addr,
-    Local<Value> early_transport_params,
-    Local<Value> session_ticket,
+    ngtcp2_transport_params* early_transport_params,
+    crypto::SSLSessionPointer early_session_ticket,
     Local<Value> dcid_value,
     QlogMode qlog) {
   CHECK_NULL(connection_);
@@ -2816,29 +2789,12 @@ bool QuicSession::InitClient(
 
   CHECK(DeriveAndInstallInitialKey(*this, this->dcid()));
 
-  // Remote Transport Params
-  if (early_transport_params->IsArrayBufferView()) {
-    if (set_early_transport_params(early_transport_params)) {
-      Debug(this, "Using provided early transport params");
-      crypto_context_->set_option(QUICCLIENTSESSION_OPTION_RESUME);
-    } else {
-      Debug(this, "Ignoring invalid early transport params");
-    }
-  }
-
-  // Session Ticket
-  if (session_ticket->IsArrayBufferView()) {
-    if (set_session(session_ticket)) {
-      Debug(this, "Using provided session ticket");
-      crypto_context_->set_option(QUICCLIENTSESSION_OPTION_RESUME);
-    } else {
-      Debug(this, "Ignoring provided session ticket");
-    }
-  }
+  if (early_transport_params != nullptr)
+    ngtcp2_conn_set_early_remote_transport_params(conn, early_transport_params);
+  crypto_context_->set_session(std::move(early_session_ticket));
 
   UpdateIdleTimer();
   UpdateDataStats();
-  return true;
 }
 
 // Static ngtcp2 callbacks are registered when ngtcp2 when a new ngtcp2_conn is
@@ -3534,31 +3490,85 @@ void QuicSessionUpdateKey(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(session->crypto_context()->InitiateKeyUpdate());
 }
 
+// When a client wishes to resume a prior TLS session, it must specify both
+// the remember transport parameters and remembered TLS session ticket. Those
+// will each be provided as a TypedArray. The DecodeTransportParams and
+// DecodeSessionTicket functions handle those. If the argument is undefined,
+// then resumption is not used.
+
+bool DecodeTransportParams(
+    Local<Value> value,
+    ngtcp2_transport_params* params) {
+  if (value->IsUndefined())
+    return false;
+  CHECK(value->IsArrayBufferView());
+  ArrayBufferViewContents<uint8_t> sbuf(value.As<ArrayBufferView>());
+  if (sbuf.length() != sizeof(ngtcp2_transport_params))
+    return false;
+  memcpy(&params, sbuf.data(), sizeof(ngtcp2_transport_params));
+  return true;
+}
+
+crypto::SSLSessionPointer DecodeSessionTicket(Local<Value> value) {
+  if (value->IsUndefined())
+    return {};
+  CHECK(value->IsArrayBufferView());
+  ArrayBufferViewContents<unsigned char> sbuf(value.As<ArrayBufferView>());
+  return crypto::GetTLSSession(sbuf.data(), sbuf.length());
+}
+
+void QuicSessionStartHandshake(const FunctionCallbackInfo<Value>& args) {
+  QuicSession* session;
+  ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
+  session->StartHandshake();
+}
+
 void NewQuicClientSession(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   QuicSocket* socket;
   int32_t family;
   uint32_t port;
-  uint32_t flags;
   SecureContext* sc;
   SocketAddress remote_addr;
-
+  int32_t preferred_address_policy;
+  PreferredAddressStrategy preferred_address_strategy;
   uint32_t options = QUICCLIENTSESSION_OPTION_VERIFY_HOSTNAME_IDENTITY;
   std::string alpn(NGTCP2_ALPN_H3);
 
-  CHECK(args[0]->IsObject());
-  CHECK(args[1]->Int32Value(env->context()).To(&family));
-  CHECK(args[3]->Uint32Value(env->context()).To(&port));
-  CHECK(args[4]->Uint32Value(env->context()).To(&flags));
-  CHECK(args[5]->IsObject());
-  CHECK(args[12]->Uint32Value(env->context()).To(&options));
-  ASSIGN_OR_RETURN_UNWRAP(&socket, args[0].As<Object>());
-  ASSIGN_OR_RETURN_UNWRAP(&sc, args[5].As<Object>());
+  enum ARG_IDX : int {
+    SOCKET,
+    TYPE,
+    IP,
+    PORT,
+    SECURE_CONTEXT,
+    SNI,
+    REMOTE_TRANSPORT_PARAMS,
+    SESSION_TICKET,
+    DCID,
+    PREFERRED_ADDRESS_POLICY,
+    ALPN,
+    OPTIONS,
+    QLOG,
+    AUTO_START
+  };
 
-  PreferredAddressStrategy preferred_address_strategy;
-  int32_t preferred_address_policy;
-  CHECK(args[10]->Int32Value(env->context()).To(&preferred_address_policy));
+  CHECK(args[ARG_IDX::SOCKET]->IsObject());
+  CHECK(args[ARG_IDX::SECURE_CONTEXT]->IsObject());
+  CHECK(args[ARG_IDX::IP]->IsString());
+  CHECK(args[ARG_IDX::ALPN]->IsString());
+  CHECK(args[ARG_IDX::TYPE]->Int32Value(env->context()).To(&family));
+  CHECK(args[ARG_IDX::PORT]->Uint32Value(env->context()).To(&port));
+  CHECK(args[ARG_IDX::OPTIONS]->Uint32Value(env->context()).To(&options));
+  CHECK(args[ARG_IDX::AUTO_START]->IsBoolean());
+  if (!args[ARG_IDX::SNI]->IsUndefined())
+    CHECK(args[ARG_IDX::SNI]->IsString());
+
+  ASSIGN_OR_RETURN_UNWRAP(&socket, args[ARG_IDX::SOCKET].As<Object>());
+  ASSIGN_OR_RETURN_UNWRAP(&sc, args[ARG_IDX::SECURE_CONTEXT].As<Object>());
+
+  CHECK(args[ARG_IDX::PREFERRED_ADDRESS_POLICY]->Int32Value(
+      env->context()).To(&preferred_address_policy));
   switch (preferred_address_policy) {
     case QUIC_PREFERRED_ADDRESS_ACCEPT:
       preferred_address_strategy = QuicSession::UsePreferredAddressStrategy;
@@ -3567,19 +3577,24 @@ void NewQuicClientSession(const FunctionCallbackInfo<Value>& args) {
       preferred_address_strategy = QuicSession::IgnorePreferredAddressStrategy;
   }
 
-  node::Utf8Value address(env->isolate(), args[2]);
-  node::Utf8Value servername(env->isolate(), args[6]);
-  std::string hostname(*servername);
+  node::Utf8Value address(env->isolate(), args[ARG_IDX::IP]);
+  node::Utf8Value servername(env->isolate(), args[ARG_IDX::SNI]);
 
   if (!SocketAddress::New(family, *address, port, &remote_addr))
     return args.GetReturnValue().Set(ERR_FAILED_TO_CREATE_SESSION);
 
-  if (args[11]->IsString()) {
-    Utf8Value val(env->isolate(), args[11]);
-    // ALPN is a string prefixex by the length, followed by values
-    alpn = val.length();
-    alpn += *val;
-  }
+  // ALPN is a string prefixed by the length, followed by values
+  Utf8Value val(env->isolate(), args[ARG_IDX::ALPN]);
+  alpn = val.length();
+  alpn += *val;
+
+  crypto::SSLSessionPointer early_session_ticket =
+      DecodeSessionTicket(args[ARG_IDX::SESSION_TICKET]);
+  ngtcp2_transport_params early_transport_params;
+  bool has_early_transport_params =
+      DecodeTransportParams(
+          args[ARG_IDX::REMOTE_TRANSPORT_PARAMS],
+          &early_transport_params);
 
   socket->ReceiveStart();
 
@@ -3589,20 +3604,26 @@ void NewQuicClientSession(const FunctionCallbackInfo<Value>& args) {
           socket->local_address(),
           remote_addr,
           sc,
-          args[7],
-          args[8],
-          args[9],
+          has_early_transport_params ? &early_transport_params : nullptr,
+          std::move(early_session_ticket),
+          args[ARG_IDX::DCID],
           preferred_address_strategy,
           alpn,
-          hostname,
+          std::string(*servername),
           options,
-          args[13]->IsTrue() ? QlogMode::kEnabled : QlogMode::kDisabled);
+          args[ARG_IDX::QLOG]->IsTrue() ?
+              QlogMode::kEnabled :
+              QlogMode::kDisabled);
 
-  session->SendPendingData();
-
-  // Session was created but was unable to bootstrap properly
-  if (session->is_destroyed())
-    return args.GetReturnValue().Set(ERR_FAILED_TO_CREATE_SESSION);
+  // Start the TLS handshake if the autoStart option is true
+  // (which it is by default).
+  if (args[ARG_IDX::AUTO_START]->BooleanValue(env->isolate())) {
+    session->StartHandshake();
+    // Session was created but was unable to bootstrap properly during
+    // the start of the TLS handshake.
+    if (session->is_destroyed())
+      return args.GetReturnValue().Set(ERR_FAILED_TO_CREATE_SESSION);
+  }
 
   args.GetReturnValue().Set(session->object());
 }
@@ -3658,6 +3679,7 @@ void QuicSession::Initialize(
     env->SetProtoMethod(session,
                         "setSocket",
                         QuicSessionSetSocket);
+    env->SetProtoMethod(session, "startHandshake", QuicSessionStartHandshake);
     env->set_quicclientsession_constructor_template(sessiont);
 
     env->SetMethod(target, "createClientSession", NewQuicClientSession);

--- a/src/quic/node_quic_session.h
+++ b/src/quic/node_quic_session.h
@@ -543,6 +543,23 @@ class QuicApplication : public MemoryRetainer {
   virtual void ExtendMaxStreamsRemoteBidi(uint64_t max_streams) {}
   virtual void ExtendMaxStreamData(int64_t stream_id, uint64_t max_data) {}
   virtual void ResumeStream(int64_t stream_id) {}
+  virtual void SetSessionTicketAppData(const SessionTicketAppData& app_data) {
+    // TODO(@jasnell): Different QUIC applications may wish to set some
+    // application data in the session ticket (e.g. http/3 would set
+    // server settings in the application data). For now, doing nothing
+    // as I'm just adding the basic mechanism.
+  }
+  virtual SessionTicketAppData::Status GetSessionTicketAppData(
+      const SessionTicketAppData& app_data,
+      SessionTicketAppData::Flag flag) {
+    // TODO(@jasnell): Different QUIC application may wish to set some
+    // application data in the session ticket (e.g. http/3 would set
+    // server settings in the application data). For now, doing nothing
+    // as I'm just adding the basic mechanism.
+    return flag == SessionTicketAppData::Flag::STATUS_RENEW ?
+      SessionTicketAppData::Status::TICKET_USE_RENEW :
+      SessionTicketAppData::Status::TICKET_USE;
+  }
   virtual void StreamHeaders(
       int64_t stream_id,
       int kind,
@@ -1028,6 +1045,12 @@ class QuicSession : public AsyncWrap,
       ConnectionIDStrategy strategy);
   inline void set_preferred_address_strategy(
       PreferredAddressStrategy strategy);
+
+  inline void SetSessionTicketAppData(
+      const SessionTicketAppData& app_data);
+  inline SessionTicketAppData::Status GetSessionTicketAppData(
+      const SessionTicketAppData& app_data,
+      SessionTicketAppData::Flag flag);
 
   inline void SelectPreferredAddress(
       const QuicPreferredAddress& preferred_address);

--- a/src/quic/node_quic_session.h
+++ b/src/quic/node_quic_session.h
@@ -368,6 +368,8 @@ class QuicCryptoContext : public MemoryRetainer {
   // Returns ngtcp2's understanding of the current outbound crypto level
   inline ngtcp2_crypto_level write_crypto_level() const;
 
+  inline bool early_data() const;
+
   bool is_option_set(uint32_t option) const { return options_ & option; }
 
   // Emits a single keylog line to the JavaScript layer
@@ -409,7 +411,7 @@ class QuicCryptoContext : public MemoryRetainer {
       options_ &= ~option;
   }
 
-  inline bool set_session(const unsigned char* data, size_t len);
+  inline bool set_session(crypto::SSLSessionPointer session);
 
   inline void set_tls_alert(int err);
 
@@ -433,6 +435,12 @@ class QuicCryptoContext : public MemoryRetainer {
 
   void MemoryInfo(MemoryTracker* tracker) const override;
 
+  void handshake_started() {
+    is_handshake_started_ = true;
+  }
+
+  bool is_handshake_started() const { return is_handshake_started_; }
+
   SET_MEMORY_INFO_NAME(QuicCryptoContext)
   SET_SELF_SIZE(QuicCryptoContext)
 
@@ -447,10 +455,12 @@ class QuicCryptoContext : public MemoryRetainer {
   ngtcp2_crypto_side side_;
   crypto::SSLPointer ssl_;
   QuicBuffer handshake_[3];
+  bool is_handshake_started_ = false;
   bool in_tls_callback_ = false;
   bool in_key_update_ = false;
   bool in_ocsp_request_ = false;
   bool in_client_hello_ = false;
+  bool early_data_ = false;
   uint32_t options_;
 
   v8::Global<v8::ArrayBufferView> ocsp_response_;
@@ -663,8 +673,8 @@ class QuicSession : public AsyncWrap,
       const SocketAddress& local_addr,
       const SocketAddress& remote_addr,
       crypto::SecureContext* context,
-      v8::Local<v8::Value> early_transport_params,
-      v8::Local<v8::Value> session_ticket,
+      ngtcp2_transport_params* early_transport_params,
+      crypto::SSLSessionPointer early_session_ticket,
       v8::Local<v8::Value> dcid,
       PreferredAddressStrategy preferred_address_strategy =
           IgnorePreferredAddressStrategy,
@@ -722,8 +732,8 @@ class QuicSession : public AsyncWrap,
       const SocketAddress& local_addr,
       const SocketAddress& remote_addr,
       crypto::SecureContext* context,
-      v8::Local<v8::Value> early_transport_params,
-      v8::Local<v8::Value> session_ticket,
+      ngtcp2_transport_params* early_transport_params,
+      crypto::SSLSessionPointer early_session_ticket,
       v8::Local<v8::Value> dcid,
       PreferredAddressStrategy preferred_address_strategy,
       const std::string& alpn,
@@ -736,6 +746,12 @@ class QuicSession : public AsyncWrap,
   std::string diagnostic_name() const override;
   inline QuicCID dcid() const;
 
+  // When a client QuicSession is created, if the autoStart
+  // option is true, the handshake will be immediately started.
+  // If autoStart is false, the start of the handshake will be
+  // deferred until the start handshake method is called;
+  inline void StartHandshake();
+
   QuicApplication* application() const { return application_.get(); }
 
   QuicCryptoContext* crypto_context() const { return crypto_context_.get(); }
@@ -745,6 +761,8 @@ class QuicSession : public AsyncWrap,
   BaseObjectPtr<QuicStream> CreateStream(int64_t id);
   BaseObjectPtr<QuicStream> FindStream(int64_t id) const;
   inline bool HasStream(int64_t id) const;
+
+  inline bool allow_early_data() const;
 
   // Returns true if StartGracefulClose() has been called and the
   // QuicSession is currently in the process of a graceful close.
@@ -889,10 +907,8 @@ class QuicSession : public AsyncWrap,
   inline void set_last_error(int32_t family, int error_code);
 
   inline void set_remote_transport_params();
-  bool set_early_transport_params(v8::Local<v8::Value> buffer);
   bool set_socket(QuicSocket* socket, bool nat_rebinding = false);
   int set_session(SSL_SESSION* session);
-  bool set_session(v8::Local<v8::Value> buffer);
 
   const StreamsMap& streams() const { return streams_; }
 
@@ -1082,11 +1098,11 @@ class QuicSession : public AsyncWrap,
       QlogMode qlog);
 
   // Initialize the QuicSession as a client
-  bool InitClient(
+  void InitClient(
       const SocketAddress& local_addr,
       const SocketAddress& remote_addr,
-      v8::Local<v8::Value> early_transport_params,
-      v8::Local<v8::Value> session_ticket,
+      ngtcp2_transport_params* early_transport_params,
+      crypto::SSLSessionPointer early_session_ticket,
       v8::Local<v8::Value> dcid,
       QlogMode qlog);
 

--- a/src/quic/node_quic_session.h
+++ b/src/quic/node_quic_session.h
@@ -1064,16 +1064,23 @@ class QuicSession : public AsyncWrap,
   // complete.
   class SendSessionScope {
    public:
-    explicit SendSessionScope(QuicSession* session) : session_(session) {
+    explicit SendSessionScope(
+        QuicSession* session,
+        bool wait_for_handshake = false)
+        : session_(session),
+          wait_for_handshake_(wait_for_handshake) {
       CHECK(session_);
     }
 
     ~SendSessionScope() {
-      if (!Ngtcp2CallbackScope::InNgtcp2CallbackScope(session_.get()))
+      if (!Ngtcp2CallbackScope::InNgtcp2CallbackScope(session_.get()) &&
+          (!wait_for_handshake_ ||
+           session_->crypto_context()->is_handshake_started()))
         session_->SendPendingData();
     }
 
    private:
+    bool wait_for_handshake_ = false;
     BaseObjectPtr<QuicSession> session_;
   };
 

--- a/src/quic/node_quic_socket-inl.h
+++ b/src/quic/node_quic_socket-inl.h
@@ -215,6 +215,10 @@ void QuicSocket::AddEndpoint(
     endpoint_->ReceiveStart();
 }
 
+void QuicSocket::SessionReady(BaseObjectPtr<QuicSession> session) {
+  listener_->OnSessionReady(session);
+}
+
 }  // namespace quic
 }  // namespace node
 

--- a/src/quic/node_quic_socket.h
+++ b/src/quic/node_quic_socket.h
@@ -320,6 +320,7 @@ class QuicSocket : public AsyncWrap,
       const SocketAddress& remote_addr,
       std::unique_ptr<QuicPacket> packet,
       BaseObjectPtr<QuicSession> session = BaseObjectPtr<QuicSession>());
+  inline void SessionReady(BaseObjectPtr<QuicSession> session);
   inline void set_server_busy(bool on);
   inline void set_diagnostic_packet_loss(double rx = 0.0, double tx = 0.0);
   inline void StopListening();

--- a/src/quic/node_quic_stream.cc
+++ b/src/quic/node_quic_stream.cc
@@ -147,7 +147,7 @@ int QuicStream::DoShutdown(ShutdownWrap* req_wrap) {
   if (is_destroyed())
     return UV_EPIPE;
 
-  QuicSession::SendSessionScope send_scope(session());
+  QuicSession::SendSessionScope send_scope(session(), true);
 
   if (is_writable()) {
     Debug(this, "Shutdown writable side");
@@ -180,7 +180,7 @@ int QuicStream::DoWrite(
     return 0;
   }
 
-  QuicSession::SendSessionScope send_scope(session());
+  QuicSession::SendSessionScope send_scope(session(), true);
 
   Debug(this, "Queuing %" PRIu64 " bytes of data from %d buffers",
         length, nbufs);

--- a/test/parallel/test-quic-client-server.js
+++ b/test/parallel/test-quic-client-server.js
@@ -256,12 +256,10 @@ server.on('ready', common.mustCall(() => {
     assert.strictEqual(response.toString(), 'hello');
   }));
 
-  req.on('sessionTicket', common.mustCall((id, ticket, params) => {
+  req.on('sessionTicket', common.mustCall((ticket, params) => {
     debug('Session ticket received');
-    assert(id instanceof Buffer);
     assert(ticket instanceof Buffer);
     assert(params instanceof Buffer);
-    debug('  ID: %s', id.toString('hex'));
     debug('  Ticket: %s', ticket.toString('hex'));
     debug('  Params: %s', params.toString('hex'));
   }, 2));

--- a/test/parallel/test-quic-errors-quicsession-openstream.js
+++ b/test/parallel/test-quic-errors-quicsession-openstream.js
@@ -66,6 +66,9 @@ server.on('ready', common.mustCall(() => {
     });
   });
 
+  req.on('ready', common.mustCall());
+  req.on('secure', common.mustCall());
+
   // Unidirectional streams are not allowed. openStream will succeeed
   // but the stream will be destroyed immediately. The underlying
   // QuicStream C++ handle will not be created.

--- a/test/parallel/test-quic-quicendpoint-address.js
+++ b/test/parallel/test-quic-quicendpoint-address.js
@@ -23,16 +23,12 @@ async function Test1(options, address) {
   server.listen({ key, cert, ca, alpn: 'zzz' });
 
   await once(server, 'ready');
-
   assert.strictEqual(server.endpoints.length, 1);
-
   const endpoint = server.endpoints[0];
   assert.strictEqual(endpoint.bound, true);
-  assert.strictEqual(endpoint.closing, false);
   assert.strictEqual(endpoint.destroyed, false);
   assert.strictEqual(typeof endpoint.address.port, 'number');
   assert.strictEqual(endpoint.address.address, address);
-
   server.close();
   assert.strictEqual(endpoint.destroyed, true);
 }
@@ -54,7 +50,6 @@ async function Test2() {
   {
     const endpoint = server.endpoints[0];
     assert.strictEqual(endpoint.bound, true);
-    assert.strictEqual(endpoint.closing, false);
     assert.strictEqual(endpoint.destroyed, false);
     assert.strictEqual(endpoint.address.family, 'IPv6');
     assert.strictEqual(typeof endpoint.address.port, 'number');
@@ -64,7 +59,6 @@ async function Test2() {
   {
     const endpoint = server.endpoints[1];
     assert.strictEqual(endpoint.bound, true);
-    assert.strictEqual(endpoint.closing, false);
     assert.strictEqual(endpoint.destroyed, false);
     assert.strictEqual(endpoint.address.family, 'IPv4');
     assert.strictEqual(typeof endpoint.address.port, 'number');
@@ -90,4 +84,4 @@ if (common.hasIPv6) {
     Test2());
 }
 
-Promise.allSettled(tests);
+Promise.all(tests);

--- a/test/parallel/test-quic-quicsession-resume.js
+++ b/test/parallel/test-quic-quicsession-resume.js
@@ -1,0 +1,100 @@
+'use strict';
+
+// Tests a simple QUIC client/server round-trip
+
+const common = require('../common');
+if (!common.hasQuic)
+  common.skip('missing quic');
+
+const { Buffer } = require('buffer');
+const Countdown = require('../common/countdown');
+const assert = require('assert');
+const {
+  key,
+  cert,
+  ca,
+  debug,
+} = require('../common/quic');
+
+const { createSocket } = require('quic');
+
+const options = { key, cert, ca, alpn: 'zzz' };
+
+const server = createSocket({ server: options });
+const client = createSocket({ client: options });
+
+const countdown = new Countdown(2, () => {
+  server.close();
+  client.close();
+});
+
+server.listen();
+server.on('session', common.mustCall((session) => {
+  session.on('secure', common.mustCall(() => {
+    assert(session.earlyData);
+  }));
+
+  session.on('stream', common.mustCall((stream) => {
+    stream.resume();
+  }));
+}, 2));
+
+server.on('ready', common.mustCall(() => {
+  const req = client.connect({
+    address: common.localhostIPv4,
+    port: server.endpoints[0].address.port,
+  });
+
+  const stream = req.openStream({ halfOpen: true });
+  stream.end('hello');
+  stream.resume();
+  stream.on('close', () => countdown.dec());
+
+  req.on('sessionTicket', common.mustCall((ticket, params) => {
+    assert(ticket instanceof Buffer);
+    assert(params instanceof Buffer);
+    debug('  Ticket: %s', ticket.toString('hex'));
+    debug('  Params: %s', params.toString('hex'));
+
+    // Destroy this initial client session...
+    req.destroy();
+
+    // Wait a tick then start a new one.
+    setImmediate(newSession, ticket, params);
+  }, 1));
+
+  function newSession(sessionTicket, remoteTransportParams) {
+    const req = client.connect({
+      address: common.localhostIPv4,
+      port: server.endpoints[0].address.port,
+      sessionTicket,
+      remoteTransportParams,
+      autoStart: false,
+    });
+
+    assert(req.allowEarlyData);
+
+    const stream = req.openStream({ halfOpen: true });
+    stream.end('hello');
+    stream.on('error', common.mustNotCall());
+    stream.on('close', common.mustCall(() => countdown.dec()));
+
+    req.startHandshake();
+
+    // TODO(@jasnell): There's a slight bug in here in that
+    // calling end() will uncork the stream, causing data to
+    // be flushed to the C++ layer, which will trigger a
+    // SendPendingData that will start the handshake. That
+    // has the effect of short circuiting the intent of
+    // manual startHandshake(), which makes it not use 0RTT
+    // for the stream data.
+
+    req.on('secure', common.mustCall(() => {
+      // TODO(@jasnell): This will be false for now because no
+      // early data was sent. Once we actually start making
+      // use of early data on the client side, this should be
+      // true when the early data was accepted.
+      assert(!req.earlyData);
+    }));
+  }
+}));

--- a/test/parallel/test-quic-quicsession-resume.js
+++ b/test/parallel/test-quic-quicsession-resume.js
@@ -31,7 +31,7 @@ const countdown = new Countdown(2, () => {
 server.listen();
 server.on('session', common.mustCall((session) => {
   session.on('secure', common.mustCall(() => {
-    assert(session.earlyData);
+    assert(session.usingEarlyData);
   }));
 
   session.on('stream', common.mustCall((stream) => {
@@ -94,7 +94,7 @@ server.on('ready', common.mustCall(() => {
       // early data was sent. Once we actually start making
       // use of early data on the client side, this should be
       // true when the early data was accepted.
-      assert(!req.earlyData);
+      assert(!req.usingEarlyData);
     }));
   }
 }));


### PR DESCRIPTION
@addaleax @danbev @nodejs/quic

This is not ready to land as multiple tests fail. I'm still investigating those failures.

This PR does advance the ball forward a bit on 0RTT support but we're not quite there yet. There are a number of API design considerations that we need to address before we can completely support 0RTT.

First, an overview:

1. A 0RTT stream is a stream initiated by the client *as part of the initial handshake*. The key piece here is that the stream resource in ngtcp2 must be created before the handshake starts. Our API currently does not allow this. As soon as the client `QuicSession` is created, the handshake is started. User code does not have the opportunity to create the stream resource.

2. A 0.5RTT stream is a stream initiated by the client or server after the handshake has started but before it is finished. We currently do have the ability to create these but inside core.js currently, we defer creation of the stream resource until after the handshake completes. We will need to modify that behavior to allow earlier initiation.

3. A 1RTT stream is any stream created after the handshake completes. This is working just fine right now.

To support 0RTT streams, we either:

A. Defer the start of the TLS handshake until the user explicitly starts it. That is, rather than starting the handshake immediately upon creation of the client `QuicSession`, we make it so that the user must start it manually. Optionally under this approach we would have an `autoStart` option on creation of the client that would start the handshake immediately. This would give user code the opportunity to create the initial 0RTT stream. The api would be something like:

```js
// sessionTicket and remoteTransportParams are required for 0RTT early data
// and 0.5RTT data from the client. They resume the previous session.

const req = client.connect({ sessionTicket, remoteTransportParams, address, port })
const stream = req.openStream();
req.startHandshake();
```

If session resume is not being used (sessionTicket and remoteTransportParams are not provided) then the handshake would auto-start unless the `autoStart` option is explicitly `false`. 

A second option would be to initiate the 0RTT stream as part of the `connect()` operation. This is far more complicated with HTTP/3 because the headers need to be included also. The initiated 0RTT stream would be given to users in an event.

```js
const req = client.connect({
  sessionTicket,
  remoteTransportParams,
  stream: {
    headers: {
      ':method': 'get',
      ':path': '/',
      /* ... */
    }
  }
});

req.on('stream', (stream) => {
  if (stream.clientInitiated) {
    // this is the 0RTT stream
  } else {
    // these are push streams
  }
});
```

There may be other options here so if you have any ideas, please let me know.