### PR TITLE
quic: fix clang build

### DIFF
--- a/src/quic/node_quic_http3_application.cc
+++ b/src/quic/node_quic_http3_application.cc
@@ -105,10 +105,10 @@ void Http3Header::MemoryInfo(MemoryTracker* tracker) const {
   tracker->TrackField("value", value_);
 }
 
-template <typename T>
+template <typename M, typename T>
 void Http3Application::SetConfig(
     int idx,
-    uint64_t T::*member) {
+    M T::*member) {
   AliasedFloat64Array& buffer = env()->quic_state()->http3config_buffer;
   uint64_t flags = static_cast<uint64_t>(buffer[IDX_HTTP3_CONFIG_COUNT]);
   if (flags & (1ULL << idx))
@@ -120,9 +120,9 @@ Http3Application::Http3Application(
   : QuicApplication(session),
     alloc_info_(MakeAllocator()) {
   // Collect Configuration Details.
-  SetConfig(IDX_HTTP3_QPACK_MAX_TABLE_CAPACITY,
+  SetConfig<size_t>(IDX_HTTP3_QPACK_MAX_TABLE_CAPACITY,
             &Http3ApplicationConfig::qpack_max_table_capacity);
-  SetConfig(IDX_HTTP3_QPACK_BLOCKED_STREAMS,
+  SetConfig<size_t>(IDX_HTTP3_QPACK_BLOCKED_STREAMS,
             &Http3ApplicationConfig::qpack_blocked_streams);
   SetConfig(IDX_HTTP3_MAX_HEADER_LIST_SIZE,
             &Http3ApplicationConfig::max_header_list_size);

--- a/src/quic/node_quic_http3_application.h
+++ b/src/quic/node_quic_http3_application.h
@@ -173,8 +173,8 @@ class Http3Application final :
   void MemoryInfo(MemoryTracker* tracker) const override;
 
  private:
-  template <typename T>
-  void SetConfig(int idx, uint64_t T::*member);
+  template <typename M = uint64_t, typename T>
+  void SetConfig(int idx, M T::*member);
 
   nghttp3_conn* connection() const { return connection_.get(); }
   BaseObjectPtr<QuicStream> FindOrCreateStream(int64_t stream_id);


### PR DESCRIPTION
It seems that clang doesn't implicitly convert "unsigned long"
into "unsigned long long" for function templates.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
