### PR TITLE
quic: disable openssl quic when not using experimental-quic

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -282,8 +282,29 @@ shared_optgroup.add_option('--shared-ngtcp2-libname',
 
 shared_optgroup.add_option('--shared-ngtcp2-libpath',
     action='store',
-    dest='shared_ngctp2_libpath',
+    dest='shared_ngtcp2_libpath',
     help='a directory to search for the shared ngtcp2 DLLs')
+
+shared_optgroup.add_option('--shared-nghttp3',
+    action='store_true',
+    dest='shared_nghttp3',
+    help='link to a shared nghttp3 DLL instead of static linking')
+
+shared_optgroup.add_option('--shared-nghttp3-includes',
+    action='store',
+    dest='shared_nghttp3_includes',
+    help='directory containing nghttp3 header files')
+
+shared_optgroup.add_option('--shared-nghttp3-libname',
+    action='store',
+    dest='shared_nghttp3_libname',
+    default='nghttp3',
+    help='alternative lib name to link to [default: %default]')
+
+shared_optgroup.add_option('--shared-nghttp3-libpath',
+    action='store',
+    dest='shared_nghttp3_libpath',
+    help='a directory to search for the shared nghttp3 DLLs')
 
 shared_optgroup.add_option('--shared-openssl',
     action='store_true',

--- a/deps/openssl/openssl.gyp
+++ b/deps/openssl/openssl.gyp
@@ -16,6 +16,13 @@
         'OPENSSL_NO_HW',
       ],
       'conditions': [
+        [
+          # Disable building QUIC support in openssl if experimental_quic
+          # is not enabled.
+          'experimental_quic!=1', {
+            'defines': ['OPENSSL_NO_QUIC=1'],
+          }
+        ],
         [ 'openssl_no_asm==1', {
           'includes': ['./openssl_no_asm.gypi'],
         }, 'target_arch=="arm64" and OS=="win"', {

--- a/node.gyp
+++ b/node.gyp
@@ -21,6 +21,7 @@
     'node_shared_libuv%': 'false',
     'node_shared_nghttp2%': 'false',
     'node_shared_ngtcp2%': 'false',
+    'node_shared_nghttp3%': 'false',
     'node_use_openssl%': 'true',
     'node_shared_openssl%': 'false',
     'node_v8_options%': '',
@@ -896,7 +897,10 @@
           'node_target_type=="executable"', {
           'defines': [ 'NODE_ENABLE_LARGE_CODE_PAGES=1' ],
         }],
-        [ 'node_use_openssl=="true" and experimental_quic==1', {
+        [
+          # We can only use QUIC if using our modified, static linked
+          # OpenSSL because we have patched in the QUIC support.
+          'node_use_openssl=="true" and node_shared_openssl=="false" and experimental_quic==1', {
           'defines': ['NODE_EXPERIMENTAL_QUIC=1'],
           'sources': [
             'src/quic/node_quic_buffer.h',

--- a/node.gypi
+++ b/node.gypi
@@ -187,11 +187,23 @@
       'dependencies': [ 'deps/nghttp2/nghttp2.gyp:nghttp2' ],
     }],
 
-    [ 'node_use_openssl=="true" and experimental_quic==1 and node_shared_ngtcp2=="false"', {
-      'dependencies': [
-        'deps/ngtcp2/ngtcp2.gyp:ngtcp2',
-        'deps/nghttp3/nghttp3.gyp:nghttp3' ],
-    }],
+    [
+      'node_use_openssl=="true" and experimental_quic==1', {
+      'conditions': [
+        [
+          'node_shared_ngtcp2=="false"', {
+          'dependencies': [
+            'deps/ngtcp2/ngtcp2.gyp:ngtcp2',
+          ]}
+        ],
+        [
+          'node_shared_nghttp3=="false"', {
+          'dependencies': [
+            'deps/nghttp3/nghttp3.gyp:nghttp3'
+          ]}
+        ]
+      ]}
+    ],
 
     [ 'node_shared_brotli=="false"', {
       'dependencies': [ 'deps/brotli/brotli.gyp:brotli' ],

--- a/src/quic/node_quic.cc
+++ b/src/quic/node_quic.cc
@@ -83,7 +83,7 @@ void QuicInitSecureContext(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   CHECK(args[0]->IsObject());  // Secure Context
   CHECK(args[1]->IsString());  // groups
-  CHECK(args[2]->IsBoolean()); // early data
+  CHECK(args[2]->IsBoolean());  // early data
 
   SecureContext* sc;
   ASSIGN_OR_RETURN_UNWRAP(&sc, args[0].As<Object>(),


### PR DESCRIPTION
* shared-nghttp3 support
* disable building openssl quic patch when not using the experimental-quic compile flag
