### PR TITLE
quic: fixup test code cache

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1695,6 +1695,13 @@ TBD
 
 TBD
 
+<a id="ERR_QUIC_UNAVAILABLE"></a>
+### `ERR_QUIC_UNAVAILABLE`
+
+> Stabililty: 1 - Experimental
+
+TBD
+
 <a id="ERR_QUICCLIENTSESSION_FAILED"></a>
 ### `ERR_QUICCLIENTSESSION_FAILED`
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1308,6 +1308,7 @@ E('ERR_QUIC_ERROR', function(code, family) {
   return `QUIC session closed with ${familyType} error code ${code}`;
 }, Error);
 E('ERR_QUIC_TLS13_REQUIRED', 'QUIC requires TLS version 1.3', Error);
+E('ERR_QUIC_UNAVAILABLE', 'QUIC is unavailable', Error);
 E('ERR_REQUIRE_ESM',
   (filename, parentPath = null, packageJsonPath = null) => {
     let msg = `Must use import to load ES Module: ${filename}`;

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -245,6 +245,8 @@ const kSocketDestroyed = 4;
 let diagnosticPacketLossWarned = false;
 let warnedVerifyHostnameIdentity = false;
 
+assert(process.versions.ngtcp2 !== undefined);
+
 // Called by the C++ internals when the socket is closed.
 // When this is called, the only thing left to do is destroy
 // the QuicSocket instance.

--- a/lib/internal/quic/util.js
+++ b/lib/internal/quic/util.js
@@ -9,6 +9,9 @@ const {
   },
 } = require('internal/errors');
 
+const assert = require('internal/assert');
+assert(process.versions.ngtcp2 !== undefined);
+
 const {
   isIP,
 } = require('internal/net');

--- a/lib/quic.js
+++ b/lib/quic.js
@@ -1,6 +1,17 @@
 'use strict';
 
 const {
+  codes: {
+    ERR_QUIC_UNAVAILABLE,
+  },
+} = require('internal/errors');
+const { assertCrypto } = require('internal/util');
+
+assertCrypto();
+if (process.versions.ngtcp2 === undefined)
+  throw new ERR_QUIC_UNAVAILABLE();
+
+const {
   createSocket
 } = require('internal/quic/core');
 

--- a/src/node_native_module.cc
+++ b/src/node_native_module.cc
@@ -87,23 +87,20 @@ void NativeModuleLoader::InitializeModuleCategories() {
       "crypto",
       "https",
       "http2",
-#if !defined(NODE_EXPERIMENTAL_QUIC)
-      "quic",
-#endif
       "tls",
       "_tls_common",
       "_tls_wrap",
       "internal/http2/core",
       "internal/http2/compat",
-#if !defined(NODE_EXPERIMENTAL_QUIC)
-      "internal/quic/core",
-      "internal/quic/util",
-#endif
       "internal/policy/manifest",
       "internal/process/policy",
       "internal/streams/lazy_transform",
 #endif  // !HAVE_OPENSSL
-
+#if !defined(NODE_EXPERIMENTAL_QUIC)
+      "quic",
+      "internal/quic/core",
+      "internal/quic/util",
+#endif
       "sys",  // Deprecated.
       "wasi",  // Experimental.
       "internal/test/binding",


### PR DESCRIPTION
Testing failing when quic unavailable...

https://ci.nodejs.org/job/node-test-commit-freebsd/32019/nodes=freebsd11-x64/testReport/junit/(root)/test/parallel_test_code_cache/

```
internal/bootstrap/loaders.js:135
      mod = bindingObj[module] = getInternalBinding(module);
                                 ^

Error: No such module: quic
    at internalBinding (internal/bootstrap/loaders.js:135:34)
    at internal/quic/util.js:66:5
    at NativeModule.compileForInternalLoader (internal/bootstrap/loaders.js:276:7)
    at nativeModuleRequire (internal/bootstrap/loaders.js:305:14)
    at internal/quic/core.js:41:5
    at NativeModule.compileForInternalLoader (internal/bootstrap/loaders.js:276:7)
    at NativeModule.compileForPublicLoader (internal/bootstrap/loaders.js:218:10)
    at loadNativeModule (internal/modules/cjs/helpers.js:24:9)
    at Function.Module._load (internal/modules/cjs/loader.js:918:15)
    at Module.require (internal/modules/cjs/loader.js:1091:19)
```