### PR TITLE
quic: revert validators.js changes

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -184,11 +184,10 @@ function ClientRequest(input, options, cb) {
     method = this.method = 'GET';
   }
 
-  validateInteger(
-    options.maxHeaderSize,
-    'maxHeaderSize',
-    { min: 0, allowUndefined: true });
-  this.maxHeaderSize = options.maxHeaderSize;
+  const maxHeaderSize = options.maxHeaderSize;
+  if (maxHeaderSize !== undefined)
+    validateInteger(maxHeaderSize, 'maxHeaderSize', 0);
+  this.maxHeaderSize = maxHeaderSize;
 
   const insecureHTTPParser = options.insecureHTTPParser;
   if (insecureHTTPParser !== undefined &&

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -330,11 +330,10 @@ function Server(options, requestListener) {
   this[kIncomingMessage] = options.IncomingMessage || IncomingMessage;
   this[kServerResponse] = options.ServerResponse || ServerResponse;
 
-  validateInteger(
-    options.maxHeaderSize,
-    'maxHeaderSize',
-    { min: 0, allowUndefined: true });
-  this.maxHeaderSize = options.maxHeaderSize;
+  const maxHeaderSize = options.maxHeaderSize;
+  if (maxHeaderSize !== undefined)
+    validateInteger(maxHeaderSize, 'maxHeaderSize', 0);
+  this.maxHeaderSize = maxHeaderSize;
 
   const insecureHTTPParser = options.insecureHTTPParser;
   if (insecureHTTPParser !== undefined &&

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1227,8 +1227,8 @@ function chmodSync(path, mode) {
 function lchown(path, uid, gid, callback) {
   callback = makeCallback(callback);
   path = getValidatedPath(path);
-  validateInteger(uid, 'uid', { min: -1, max: kMaxUserId });
-  validateInteger(gid, 'gid', { min: -1, max: kMaxUserId });
+  validateInteger(uid, 'uid', -1, kMaxUserId);
+  validateInteger(gid, 'gid', -1, kMaxUserId);
   const req = new FSReqCallback();
   req.oncomplete = callback;
   binding.lchown(pathModule.toNamespacedPath(path), uid, gid, req);
@@ -1236,8 +1236,8 @@ function lchown(path, uid, gid, callback) {
 
 function lchownSync(path, uid, gid) {
   path = getValidatedPath(path);
-  validateInteger(uid, 'uid', { min: -1, max: kMaxUserId });
-  validateInteger(gid, 'gid', { min: -1, max: kMaxUserId });
+  validateInteger(uid, 'uid', -1, kMaxUserId);
+  validateInteger(gid, 'gid', -1, kMaxUserId);
   const ctx = { path };
   binding.lchown(pathModule.toNamespacedPath(path), uid, gid, undefined, ctx);
   handleErrorFromBinding(ctx);
@@ -1245,8 +1245,8 @@ function lchownSync(path, uid, gid) {
 
 function fchown(fd, uid, gid, callback) {
   validateInt32(fd, 'fd', 0);
-  validateInteger(uid, 'uid', { min: -1, max: kMaxUserId });
-  validateInteger(gid, 'gid', { min: -1, max: kMaxUserId });
+  validateInteger(uid, 'uid', -1, kMaxUserId);
+  validateInteger(gid, 'gid', -1, kMaxUserId);
 
   const req = new FSReqCallback();
   req.oncomplete = makeCallback(callback);
@@ -1255,8 +1255,8 @@ function fchown(fd, uid, gid, callback) {
 
 function fchownSync(fd, uid, gid) {
   validateInt32(fd, 'fd', 0);
-  validateInteger(uid, 'uid', { min: -1, max: kMaxUserId });
-  validateInteger(gid, 'gid', { min: -1, max: kMaxUserId });
+  validateInteger(uid, 'uid', -1, kMaxUserId);
+  validateInteger(gid, 'gid', -1, kMaxUserId);
 
   const ctx = {};
   binding.fchown(fd, uid, gid, undefined, ctx);
@@ -1266,8 +1266,8 @@ function fchownSync(fd, uid, gid) {
 function chown(path, uid, gid, callback) {
   callback = makeCallback(callback);
   path = getValidatedPath(path);
-  validateInteger(uid, 'uid', { min: -1, max: kMaxUserId });
-  validateInteger(gid, 'gid', { min: -1, max: kMaxUserId });
+  validateInteger(uid, 'uid', -1, kMaxUserId);
+  validateInteger(gid, 'gid', -1, kMaxUserId);
 
   const req = new FSReqCallback();
   req.oncomplete = callback;
@@ -1276,8 +1276,8 @@ function chown(path, uid, gid, callback) {
 
 function chownSync(path, uid, gid) {
   path = getValidatedPath(path);
-  validateInteger(uid, 'uid', { min: -1, max: kMaxUserId });
-  validateInteger(gid, 'gid', { min: -1, max: kMaxUserId });
+  validateInteger(uid, 'uid', -1, kMaxUserId);
+  validateInteger(gid, 'gid', -1, kMaxUserId);
   const ctx = { path };
   binding.chown(pathModule.toNamespacedPath(path), uid, gid, undefined, ctx);
   handleErrorFromBinding(ctx);

--- a/lib/internal/crypto/scrypt.js
+++ b/lib/internal/crypto/scrypt.js
@@ -108,7 +108,7 @@ function check(password, salt, keylen, options) {
     }
     if (options.maxmem !== undefined) {
       maxmem = options.maxmem;
-      validateInteger(maxmem, 'maxmem', { min: 0 });
+      validateInteger(maxmem, 'maxmem', 0);
     }
     if (N === 0) N = defaults.N;
     if (r === 0) r = defaults.r;

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -1586,8 +1586,16 @@ class QuicSocket extends EventEmitter {
       rx = 0.0,
       tx = 0.0
     } = { ...options };
-    validateNumber(rx, 'options.rx', { min: 0.0, max: 1.0 });
-    validateNumber(tx, 'options.tx', { min: 0.0, max: 1.0 });
+    validateNumber(
+      rx,
+      'options.rx',
+      /* min */ 0.0,
+      /* max */ 1.0);
+    validateNumber(
+      tx,
+      'options.tx',
+      /* min */ 0.0,
+      /* max */ 1.0);
     if ((rx > 0.0 || tx > 0.0) && !diagnosticPacketLossWarned) {
       diagnosticPacketLossWarned = true;
       process.emitWarning(
@@ -2876,8 +2884,8 @@ class QuicStream extends Duplex {
     if (this.destroyed || this.#closed)
       return;
 
-    validateInteger(offset, 'options.offset', { min: -1 });
-    validateInteger(length, 'options.length', { min: -1 });
+    validateInteger(offset, 'options.offset', /* min */ -1);
+    validateInteger(length, 'options.length', /* min */ -1);
 
     if (fd instanceof fsPromisesInternal.FileHandle)
       fd = fd.fd;
@@ -3079,7 +3087,8 @@ class QuicStream extends Duplex {
 
     const { terminal } = { ...options };
 
-    validateBoolean(terminal, 'options.terminal', { allowUndefined: true });
+    if (terminal !== undefined)
+      validateBoolean(terminal, 'options.terminal');
     validateObject(headers, 'headers');
 
     // TODO(@jasnell): The validators here are specific to the QUIC

--- a/lib/internal/quic/util.js
+++ b/lib/internal/quic/util.js
@@ -166,70 +166,103 @@ function validateTransportParams(params) {
     },
   } = { h3: {}, ...params };
 
-  validateInteger(
-    activeConnectionIdLimit,
-    'options.activeConnectionIdLimit',
-    { min: 2, max: 8, allowUndefined: true });
-  validateInteger(
-    maxStreamDataBidiLocal,
-    'options.maxStreamDataBidiLocal',
-    { min: 0, allowUndefined: true });
-  validateInteger(
-    maxStreamDataBidiRemote,
-    'options.maxStreamDataBidiRemote',
-    { min: 0, allowUndefined: true });
-  validateInteger(
-    maxStreamDataUni,
-    'options.maxStreamDataUni',
-    { min: 0, allowUndefined: true });
-  validateInteger(
-    maxData,
-    'options.maxData',
-    { min: 0, allowUndefined: true });
-  validateInteger(
-    maxStreamsBidi,
-    'options.maxStreamsBidi',
-    { min: 0, allowUndefined: true });
-  validateInteger(
-    maxStreamsUni,
-    'options.maxStreamsUni',
-    { min: 0, allowUndefined: true });
-  validateInteger(
-    idleTimeout,
-    'options.idleTimeout',
-    { min: 0, allowUndefined: true });
-  validateInteger(
-    maxPacketSize,
-    'options.maxPacketSize',
-    { min: 0, allowUndefined: true });
-  validateInteger(
-    maxAckDelay,
-    'options.maxAckDelay',
-    { min: 0, allowUndefined: true });
-  validateInteger(
-    qpackMaxTableCapacity,
-    'options.h3.qpackMaxTableCapacity',
-    { min: 0, allowUndefined: true });
-  validateInteger(
-    qpackBlockedStreams,
-    'options.h3.qpackBlockedStreams',
-    { min: 0, allowUndefined: true });
-  validateInteger(
-    maxHeaderListSize,
-    'options.h3.maxHeaderListSize',
-    { min: 0, allowUndefined: true });
-  validateInteger(
-    maxPushes,
-    'options.h3.maxPushes',
-    { min: 0, allowUndefined: true });
-  validateInteger(
-    maxHeaderPairs,
-    'options.h3.maxHeaderPairs',
-    { min: 0, allowUndefined: true });
-  validateInteger(
-    maxHeaderLength,
-    'options.h3.maxHeaderLength',
-    { min: 0, allowUndefined: true });
+  if (activeConnectionIdLimit !== undefined) {
+    validateInteger(
+      activeConnectionIdLimit,
+      'options.activeConnectionIdLimit',
+      /* min */ 2,
+      /* max */ 8);
+  }
+  if (maxStreamDataBidiLocal !== undefined) {
+    validateInteger(
+      maxStreamDataBidiLocal,
+      'options.maxStreamDataBidiLocal',
+      /* min */ 0);
+  }
+  if (maxStreamDataBidiRemote !== undefined) {
+    validateInteger(
+      maxStreamDataBidiRemote,
+      'options.maxStreamDataBidiRemote',
+      /* min */ 0);
+  }
+  if (maxStreamDataUni !== undefined) {
+    validateInteger(
+      maxStreamDataUni,
+      'options.maxStreamDataUni',
+      /* min */ 0);
+  }
+  if (maxData !== undefined) {
+    validateInteger(
+      maxData,
+      'options.maxData',
+      /* min */ 0);
+  }
+  if (maxStreamsBidi !== undefined) {
+    validateInteger(
+      maxStreamsBidi,
+      'options.maxStreamsBidi',
+      /* min */ 0);
+  }
+  if (maxStreamsUni !== undefined) {
+    validateInteger(
+      maxStreamsUni,
+      'options.maxStreamsUni',
+      /* min */ 0);
+  }
+  if (idleTimeout !== undefined) {
+    validateInteger(
+      idleTimeout,
+      'options.idleTimeout',
+      /* min */ 0);
+  }
+  if (maxPacketSize !== undefined) {
+    validateInteger(
+      maxPacketSize,
+      'options.maxPacketSize',
+      /* min */ 0);
+  }
+  if (maxAckDelay !== undefined) {
+    validateInteger(
+      maxAckDelay,
+      'options.maxAckDelay',
+      /* min */ 0);
+  }
+  if (qpackMaxTableCapacity !== undefined) {
+    validateInteger(
+      qpackMaxTableCapacity,
+      'options.h3.qpackMaxTableCapacity',
+      /* min */ 0);
+  }
+  if (qpackBlockedStreams !== undefined) {
+    validateInteger(
+      qpackBlockedStreams,
+      'options.h3.qpackBlockedStreams',
+      /* min */ 0);
+  }
+  if (maxHeaderListSize !== undefined) {
+    validateInteger(
+      maxHeaderListSize,
+      'options.h3.maxHeaderListSize',
+      /* min */ 0);
+  }
+  if (maxPushes !== undefined) {
+    validateInteger(
+      maxPushes,
+      'options.h3.maxPushes',
+      /* min */ 0);
+  }
+  if (maxHeaderPairs !== undefined) {
+    validateInteger(
+      maxHeaderPairs,
+      'options.h3.maxHeaderPairs',
+      /* min */ 0);
+  }
+  if (maxHeaderLength !== undefined) {
+    validateInteger(
+      maxHeaderLength,
+      'options.h3.maxHeaderLength',
+      /* min */ 0);
+  }
 
   validatePreferredAddress(preferredAddress);
 
@@ -294,15 +327,11 @@ function validateQuicClientSessionOptions(options = {}) {
       'cannot be an IP address');
   }
 
-  validateBuffer(
-    remoteTransportParams,
-    'options.remoteTransportParams',
-    { allowUndefined: true });
+  if (remoteTransportParams !== undefined)
+    validateBuffer(remoteTransportParams, 'options.remoteTransportParams');
 
-  validateBuffer(
-    sessionTicket,
-    'options.sessionTicket',
-    { allowUndefined: true });
+  if (sessionTicket !== undefined)
+    validateBuffer(sessionTicket, 'options.sessionTicket');
 
   let dcid;
   if (dcid_value !== undefined) {
@@ -371,11 +400,14 @@ function validateQuicStreamOptions(options = {}) {
       defaultEncoding,
       'is not a valid encoding');
   }
-  validateBoolean(halfOpen, 'options.halfOpen', { allowUndefined: true });
-  validateInteger(highWaterMark, 'options.highWaterMark', {
-    min: 0,
-    allowUndefined: true
-  });
+  if (halfOpen !== undefined)
+    validateBoolean(halfOpen, 'options.halfOpen');
+  if (highWaterMark !== undefined) {
+    validateInteger(
+      highWaterMark,
+      'options.highWaterMark',
+      /* min */ 0);
+  }
   return {
     defaultEncoding,
     halfOpen,
@@ -396,7 +428,8 @@ function validateQuicEndpointOptions(options = {}, name = 'options') {
     type = 'udp4',
     preferred = false,
   } = options;
-  validateString(address, 'options.address', { allowUndefined: true });
+  if (address !== undefined)
+    validateString(address, 'options.address');
   validatePort(port, 'options.port');
   validateString(type, 'options.type');
   validateLookup(lookup);
@@ -446,26 +479,31 @@ function validateQuicSocketOptions(options = {}) {
   validateBoolean(qlog, 'options.qlog');
   validateBoolean(disableStatelessReset, 'options.disableStatelessReset');
 
-  validateInteger(
-    retryTokenTimeout,
-    'options.retryTokenTimeout',
-    {
-      min: MIN_RETRYTOKEN_EXPIRATION,
-      max: MAX_RETRYTOKEN_EXPIRATION,
-      allowUndefined: true
-    });
-  validateInteger(
-    maxConnections,
-    'options.maxConnections',
-    { min: 1, allowUndefined: true });
-  validateInteger(
-    maxConnectionsPerHost,
-    'options.maxConnectionsPerHost',
-    { min: 1, allowUndefined: true });
-  validateInteger(
-    maxStatelessResetsPerHost,
-    'options.maxStatelessResetsPerHost',
-    { min: 1, allowUndefined: true });
+  if (retryTokenTimeout !== undefined) {
+    validateInteger(
+      retryTokenTimeout,
+      'options.retryTokenTimeout',
+      /* min */ MIN_RETRYTOKEN_EXPIRATION,
+      /* max */ MAX_RETRYTOKEN_EXPIRATION);
+  }
+  if (maxConnections !== undefined) {
+    validateInteger(
+      maxConnections,
+      'options.maxConnections',
+      /* min */ 1);
+  }
+  if (maxConnectionsPerHost !== undefined) {
+    validateInteger(
+      maxConnectionsPerHost,
+      'options.maxConnectionsPerHost',
+      /* min */ 1);
+  }
+  if (maxStatelessResetsPerHost !== undefined) {
+    validateInteger(
+      maxStatelessResetsPerHost,
+      'options.maxStatelessResetsPerHost',
+      /* min */ 1);
+  }
 
   if (statelessResetSecret !== undefined) {
     validateBuffer(statelessResetSecret, 'options.statelessResetSecret');
@@ -502,14 +540,10 @@ function validateQuicSocketListenOptions(options = {}) {
     rejectUnauthorized,
   } = options;
   validateString(alpn, 'options.alpn');
-  validateBoolean(
-    rejectUnauthorized,
-    'options.rejectUnauthorized',
-    { allowUndefined: true });
-  validateBoolean(
-    requestCert,
-    'options.requestCert',
-    { allowUndefined: true });
+  if (rejectUnauthorized !== undefined)
+    validateBoolean(rejectUnauthorized, 'options.rejectUnauthorized');
+  if (requestCert !== undefined)
+    validateBoolean(requestCert, 'options.requestCert');
 
   const transportParams =
     validateTransportParams(
@@ -532,7 +566,8 @@ function validateQuicSocketConnectOptions(options = {}) {
     type = 'udp4',
     address,
   } = options;
-  validateString(address, 'options.address', { allowUndefined: true });
+  if (address !== undefined)
+    validateString(address, 'options.address');
   return {
     type: getSocketType(type),
     address,
@@ -560,7 +595,8 @@ function validateCreateSecureContextOptions(options = {}) {
   } = options;
   validateString(ciphers, 'option.ciphers');
   validateString(groups, 'option.groups');
-  validateBoolean(earlyData, 'option.earlyData', { allowUndefined: true });
+  if (earlyData !== undefined)
+    validateBoolean(earlyData, 'option.earlyData');
 
   // Additional validation occurs within the tls
   // createSecureContext function.

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -170,12 +170,12 @@ function validateSignalName(signal, name = 'signal') {
 }
 
 const validateBuffer = hideStackFrames((buffer, name = 'buffer') => {
-    if (!isArrayBufferView(buffer)) {
-      throw new ERR_INVALID_ARG_TYPE(name,
-                                     ['Buffer', 'TypedArray', 'DataView'],
-                                     buffer);
-    }
-  });
+  if (!isArrayBufferView(buffer)) {
+    throw new ERR_INVALID_ARG_TYPE(name,
+                                   ['Buffer', 'TypedArray', 'DataView'],
+                                   buffer);
+  }
+});
 
 function validateEncoding(data, encoding) {
   const normalizedEncoding = normalizeEncoding(encoding);

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -72,12 +72,7 @@ function parseFileMode(value, name, def) {
 }
 
 const validateInteger = hideStackFrames(
-  (value, name,
-   { min = NumberMIN_SAFE_INTEGER,
-     max = NumberMAX_SAFE_INTEGER,
-     allowUndefined = false } = {}) => {
-    if (allowUndefined && value === undefined)
-      return;
+  (value, name, min = NumberMIN_SAFE_INTEGER, max = NumberMAX_SAFE_INTEGER) => {
     if (typeof value !== 'number')
       throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
     if (!NumberIsInteger(value))
@@ -122,25 +117,21 @@ const validateUint32 = hideStackFrames((value, name, positive) => {
   }
 });
 
-function validateString(value, name, { allowUndefined = false } = {}) {
-  if (allowUndefined && value === undefined)
-    return;
+function validateString(value, name) {
   if (typeof value !== 'string')
     throw new ERR_INVALID_ARG_TYPE(name, 'string', value);
 }
 
 function validateNumber(value, name,
-                        { min = NumberNEGATIVE_INFINITY,
-                          max = NumberINFINITY } = {}) {
+                        min = NumberNEGATIVE_INFINITY,
+                        max = NumberINFINITY) {
   if (typeof value !== 'number')
     throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
   if (value < min || value > max)
     throw new ERR_OUT_OF_RANGE(name, `>= ${min} && <= ${max}`, value);
 }
 
-function validateBoolean(value, name, { allowUndefined = false } = {}) {
-  if (allowUndefined && value === undefined)
-    return;
+function validateBoolean(value, name) {
   if (typeof value !== 'boolean')
     throw new ERR_INVALID_ARG_TYPE(name, 'boolean', value);
 }
@@ -178,10 +169,7 @@ function validateSignalName(signal, name = 'signal') {
   }
 }
 
-const validateBuffer = hideStackFrames(
-  (buffer, name = 'buffer', { allowUndefined = false } = {}) => {
-    if (allowUndefined && buffer === undefined)
-      return;
+const validateBuffer = hideStackFrames((buffer, name = 'buffer') => {
     if (!isArrayBufferView(buffer)) {
       throw new ERR_INVALID_ARG_TYPE(name,
                                      ['Buffer', 'TypedArray', 'DataView'],

--- a/test/parallel/test-validators.js
+++ b/test/parallel/test-validators.js
@@ -33,8 +33,6 @@ const invalidArgValueError = {
   [1, false, [], {}, NaN, 1n, null, undefined].forEach((i) => {
     assert.throws(() => validateString(i, 'foo'), invalidArgTypeError);
   });
-
-  validateString(undefined, 'foo', { allowUndefined: true });
 }
 
 {
@@ -47,8 +45,6 @@ const invalidArgValueError = {
   [1, false, '', {}, [], 1n, null, undefined].forEach((i) => {
     assert.throws(() => validateBuffer(i, 'foo'), invalidArgTypeError);
   });
-
-  validateBuffer(undefined, 'foo', { allowUndefined: true });
 }
 
 {
@@ -68,12 +64,11 @@ const invalidArgValueError = {
   validateInteger(
     MAX_SAFE_INTEGER + 1,
     'foo',
-    { min: 0, max: MAX_SAFE_INTEGER + 1 });
+    0, MAX_SAFE_INTEGER + 1);
   validateInteger(
     MIN_SAFE_INTEGER - 1,
     'foo',
-    { min: MIN_SAFE_INTEGER - 1 });
-  validateInteger(undefined, 'foo', { allowUndefined: true });
+    MIN_SAFE_INTEGER - 1);
 }
 
 {
@@ -104,8 +99,6 @@ const invalidArgValueError = {
       validateBoolean(val, 'foo');
     }, invalidArgTypeError);
   });
-
-  validateBoolean(undefined, 'foo', { allowUndefined: true });
 }
 
 {


### PR DESCRIPTION
There was pushback in nodejs/node on altering the validators
to use the allowUndefined option so revert that here. Not
going to fight that battle.
